### PR TITLE
Fix .IconImage spacing bug

### DIFF
--- a/taffybar.css
+++ b/taffybar.css
@@ -47,7 +47,7 @@
 	opacity: .3;
 }
 
-.IconImage {
+.IconContainer.Normal .IconImage {
 	transition: opacity .5s;
 	padding: 2px;
 	opacity: 1;


### PR DESCRIPTION
This adds the `.Normal` class to the parent selector of `.IconImage`.
It's necessary because the icon widgets are hidden instead of removed
when the windows are closed. Without this class, the icons are hidden,
but the padding remains. Fixes #318

There should still be a default fallback icon, otherwise the padding
appears without an icon while the window is open. See #319.