### PR TITLE
Remove default icon padding for inactive widgets

### DIFF
--- a/src/System/Taffybar/Widget/Workspaces.hs
+++ b/src/System/Taffybar/Widget/Workspaces.hs
@@ -702,7 +702,7 @@ updateIconWidget _ IconWidget
   let setIconWidgetProperties = do
         info <- maybe (return IINone) (getIconInfo cfg) windowData
         let imgSize = windowIconSize cfg
-            statusString = maybe "nodata" getWindowStatusString windowData
+            statusString = maybe "Nodata" getWindowStatusString windowData
             iconInfo =
               case info of
                 IINone ->

--- a/taffybar.css
+++ b/taffybar.css
@@ -42,15 +42,19 @@
 	background-color: @urgent-window-color;
 }
 
+.IconImage {
+	transition: opacity .5s;
+	padding: 2px;
+	opacity: 1;
+}
+
 .IconContainer.Minimized .IconImage {
 	transition: opacity .5s;
 	opacity: .3;
 }
 
-.IconContainer.Normal .IconImage {
-	transition: opacity .5s;
-	padding: 2px;
-	opacity: 1;
+.IconContainer.Nodata .IconImage {
+  padding: 0px;
 }
 
 #Windows {


### PR DESCRIPTION
1. Reverts the default `.IconImage` selector change in #320
2. Fixes case of inactive class name: "nodata" -> "Nodata"
3. Removes padding for inactive widgets.

Closes #318