### PR TITLE
PollingLabel shouldnt strip whitespace

### DIFF
--- a/src/System/Taffybar/Widget/Generic/PollingLabel.hs
+++ b/src/System/Taffybar/Widget/Generic/PollingLabel.hs
@@ -50,7 +50,7 @@ pollingLabelNewWithTooltip initialString interval cmd =
 
     let updateLabel (labelStr, tooltipStr) =
           runOnUIThread $ do
-            labelSetMarkup l $ T.strip $ T.pack labelStr
+            labelSetMarkup l $ T.pack labelStr
             widgetSetTooltipMarkup l $ T.pack <$> tooltipStr
 
     _ <- onWidgetRealize l $ void $ foreverWithDelay interval $


### PR DESCRIPTION
IMO, formatting shouldnt be the responsibility of the generic widget, for the same reason that HTML entities are not stripped by this widget `Proper input sanitization is up to the caller`

there is, of course, a practical reason not to strip whitespace as well; stripping the whitespace breaks my fixed-width monospace labels