### PR TITLE
Rename inactive widget CSS class name

### DIFF
--- a/src/System/Taffybar/Widget/Workspaces.hs
+++ b/src/System/Taffybar/Widget/Workspaces.hs
@@ -684,7 +684,7 @@ getWindowStatusString WindowData { windowUrgent = True } = show Urgent
 getWindowStatusString _ = "Normal"
 
 possibleStatusStrings :: [String]
-possibleStatusStrings = [show Active, show Urgent, "Minimized", "Normal", "Nodata"]
+possibleStatusStrings = [show Active, show Urgent, "Minimized", "Normal", "Inactive"]
 
 updateIconWidget
   :: IconController
@@ -702,7 +702,7 @@ updateIconWidget _ IconWidget
   let setIconWidgetProperties = do
         info <- maybe (return IINone) (getIconInfo cfg) windowData
         let imgSize = windowIconSize cfg
-            statusString = maybe "Nodata" getWindowStatusString windowData
+            statusString = maybe "Inactive" getWindowStatusString windowData
             iconInfo =
               case info of
                 IINone ->

--- a/taffybar.css
+++ b/taffybar.css
@@ -53,7 +53,7 @@
 	opacity: .3;
 }
 
-.IconContainer.Nodata .IconImage {
+.IconContainer.Inactive .IconImage {
   padding: 0px;
 }
 


### PR DESCRIPTION
This renames the CSS class that is applied to widgets with windows that
were removed from "Nodata" to "Inactive". See related discussion on #326.