### PR TITLE
Brightness widget; looked up by udev and polled by udev monitor

### DIFF
--- a/src/System/Taffybar/Information/Brightness.hs
+++ b/src/System/Taffybar/Information/Brightness.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+module System.Taffybar.Information.Brightness where
+
+import System.UDev.Context
+import System.UDev.Device
+import System.UDev.Monitor
+
+import System.UDev.Enumerate
+import System.UDev.List
+
+import Control.Concurrent (Chan, newChan, writeChan, threadWaitRead)
+
+import Control.Monad (when)
+
+import Data.ByteString (ByteString())
+
+import System.Taffybar.Util (backgroundLoop)
+import System.Taffybar.Util.ReadByteString (parseInt)
+
+--Only returns the first match
+scanForDeviceBySubsystem :: UDev -> Subsystem -> IO Device
+scanForDeviceBySubsystem udev subSysName = do
+  e <- newEnumerate udev
+  addMatchSubsystem e subSysName
+  scanDevices e 
+  Just ls <- getListEntry e
+  path <- getName ls
+  newFromSysPath udev path
+  
+getInt :: ByteString -> Device -> IO Int
+getInt name dev = parseInt <$> getSysattrValue dev name
+
+readBrightnessValues :: IO (Chan Double)
+readBrightnessValues = withUDev $ \udev -> do
+  max_brightness <- scanForDeviceBySubsystem udev "backlight" >>= getInt "max_brightness"
+  monitor <- newFromNetlink udev UDevId
+  -- Uncomment this when next version of udev is released:
+  -- filterAddMatchSubsystemDevtype monitor "backlight" Nothing
+  enableReceiving monitor
+  fd <- getFd monitor
+  chan <- newChan
+  backgroundLoop $ do
+    threadWaitRead fd
+    dev <- receiveDevice monitor
+    -- replace this guard with above filterAddMatchSubsystemDevtype when next udev is released
+    when (getSubsystem dev == Just "backlight") $ do
+      actual_brightness <- getInt "actual_brightness" dev
+      let percent = fromIntegral actual_brightness / fromIntegral max_brightness
+      writeChan chan percent
+  return chan
+

--- a/src/System/Taffybar/Information/Brightness.hs
+++ b/src/System/Taffybar/Information/Brightness.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module System.Taffybar.Information.Brightness where
+module System.Taffybar.Information.Brightness (readBrightnessValues) where
 
 import System.UDev.Context
 import System.UDev.Device

--- a/src/System/Taffybar/Information/Brightness.hs
+++ b/src/System/Taffybar/Information/Brightness.hs
@@ -23,7 +23,7 @@ scanForDeviceBySubsystem udev subSysName = do
   e <- newEnumerate udev
   addMatchSubsystem e subSysName
   scanDevices e 
-  Just ls <- getListEntry e
+  ls <- getListEntry e -- This becomes a Maybe in the next udev release
   path <- getName ls
   newFromSysPath udev path
   

--- a/src/System/Taffybar/Util.hs
+++ b/src/System/Taffybar/Util.hs
@@ -82,6 +82,15 @@ foreverWithDelay :: RealFrac a1 => a1 -> IO a -> IO ThreadId
 foreverWithDelay delay action =
   forkIO $ forever $ action >> threadDelay (floor $ delay * 1000000)
 
+backgroundLoop :: IO a -> IO ()
+backgroundLoop = void . forkIO . forever
+
+loopActionToChan :: IO a -> IO (Chan a)
+loopActionToChan action = do
+  chan <- newChan
+  backgroundLoop $ action >>= writeChan chan
+  return chan
+
 liftActionTaker
   :: (Monad m)
   => ((a -> m a) -> m b) -> (a -> ReaderT c m a) -> ReaderT c m b

--- a/src/System/Taffybar/Util.hs
+++ b/src/System/Taffybar/Util.hs
@@ -85,6 +85,7 @@ foreverWithDelay delay action =
 backgroundLoop :: IO a -> IO ()
 backgroundLoop = void . forkIO . forever
 
+-- This could take an IO (Maybe a) instead of the action doesn't return a new value on every exexecution?
 loopActionToChan :: IO a -> IO (Chan a)
 loopActionToChan action = do
   chan <- newChan

--- a/src/System/Taffybar/Util/ReadByteString.hs
+++ b/src/System/Taffybar/Util/ReadByteString.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+module System.Taffybar.Util.ReadByteString (parseInt) where
+
+import Data.ByteString (ByteString())
+import Data.Text (Text())
+import Data.Text.Encoding (decodeUtf8)
+import Data.Text.Read (decimal)
+
+--partial
+fromReader :: Either String (a, Text) -> a
+fromReader (Right (n, "")) = n
+
+parseInt :: ByteString -> Int
+parseInt = fromReader . decimal . decodeUtf8

--- a/src/System/Taffybar/Widget/Brightness.hs
+++ b/src/System/Taffybar/Widget/Brightness.hs
@@ -1,11 +1,13 @@
 module System.Taffybar.Widget.Brightness (brightnessBarNew) where
 
+import Control.Concurrent.Chan (dupChan)
 import Graphics.UI.Gtk (Widget)
-import System.Taffybar.Information.Brightness (readBrightnessValues)
+import System.Taffybar.Widget.Generic.VerticalBar (BarConfig)
 import System.Taffybar.Widget.Generic.PollingBar (verticalBarFromChannel)
+import System.Taffybar.Information.Brightness (readBrightnessValues)
 
-brightnessBarNew :: IO Widget
-brightnessBarNew = do
+brightnessBarNew :: BarConfig -> IO Widget
+brightnessBarNew cfg = do
   chan <- readBrightnessValues
   ourChan <- dupChan chan
-  verticalBarFromChannel ourChan
+  verticalBarFromChannel cfg ourChan

--- a/src/System/Taffybar/Widget/Brightness.hs
+++ b/src/System/Taffybar/Widget/Brightness.hs
@@ -1,0 +1,11 @@
+module System.Taffybar.Widget.Brightness (brightnessBarNew) where
+
+import Graphics.UI.Gtk (Widget)
+import System.Taffybar.Information.Brightness (readBrightnessValues)
+import System.Taffybar.Widget.Generic.PollingBar (verticalBarFromChannel)
+
+brightnessBarNew :: IO Widget
+brightnessBarNew = do
+  chan <- readBrightnessValues
+  ourChan <- dupChan chan
+  verticalBarFromChannel ourChan

--- a/src/System/Taffybar/Widget/Generic/PollingBar.hs
+++ b/src/System/Taffybar/Widget/Generic/PollingBar.hs
@@ -14,9 +14,13 @@ module System.Taffybar.Widget.Generic.PollingBar (
 import Control.Concurrent
 import Control.Exception.Enclosed ( tryAny )
 import Graphics.UI.Gtk
-import System.Taffybar.Widget.Util ( backgroundLoop, drawOn )
+import System.Taffybar.Util ( backgroundLoop )
+import System.Taffybar.Widget.Util ( drawOn )
 
 import System.Taffybar.Widget.Generic.VerticalBar
+
+verticalBarFromChannel :: BarConfig -> Chan Double -> IO Widget
+verticalBarFromChannel cfg chan = verticalBarFromCallback cfg $ readChan chan
 
 verticalBarFromCallback :: BarConfig -> IO Double -> IO Widget
 verticalBarFromCallback cfg action = do

--- a/src/System/Taffybar/Widget/Generic/PollingBar.hs
+++ b/src/System/Taffybar/Widget/Generic/PollingBar.hs
@@ -7,6 +7,7 @@ module System.Taffybar.Widget.Generic.PollingBar (
   BarDirection(..),
   -- * Constructors and accessors
   pollingBarNew,
+  verticalBarFromChannel,
   verticalBarFromCallback,
   defaultBarConfig
   ) where

--- a/src/System/Taffybar/Widget/Util.hs
+++ b/src/System/Taffybar/Widget/Util.hs
@@ -100,9 +100,6 @@ colorize fg bg = printf "<span%s%s>%s</span>" (attr "fg" fg) (attr "bg" bg)
           | null value = ""
           | otherwise  = printf " %scolor=\"%s\"" name value
 
-backgroundLoop :: IO a -> IO ()
-backgroundLoop = void . forkIO . forever
-
 drawOn :: WidgetClass object => object -> IO () -> IO object
 drawOn drawArea action = on drawArea realize action $> drawArea
 

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -42,6 +42,7 @@ library
                , HStringTemplate >= 0.8 && < 0.9
                , HTTP
                , X11 >= 1.5.0.1
+               , bytestring
                , cairo
                , containers
                , dbus >= 1.0.0 && < 2.0.0
@@ -83,6 +84,7 @@ library
                , transformers >= 0.3.0.0
                , transformers-base >= 0.4
                , tuple >= 0.3.0.2
+               , udev == 0.1.0.0
                , unix
                , utf8-string
                , xdg-basedir >= 0.2 && < 0.3
@@ -106,6 +108,7 @@ library
                  , System.Taffybar.Hooks
                  , System.Taffybar.IconImages
                  , System.Taffybar.Information.Battery
+                 , System.Taffybar.Information.Brightness
                  , System.Taffybar.Information.CPU
                  , System.Taffybar.Information.CPU2
                  , System.Taffybar.Information.DiskIO
@@ -123,6 +126,7 @@ library
                  , System.Taffybar.Support.PagerHints
                  , System.Taffybar.Widget
                  , System.Taffybar.Widget.Battery
+                 , System.Taffybar.Widget.Brightness
                  , System.Taffybar.Widget.CPUMonitor
                  , System.Taffybar.Widget.CommandRunner
                  , System.Taffybar.Widget.Decorators
@@ -163,6 +167,7 @@ library
                , System.Taffybar.DBus.Client.UPowerDevice
                , System.Taffybar.DBus.Client.Util
                , System.Taffybar.Util
+               , System.Taffybar.Util.ReadByteString
 
   cc-options: -fPIC
   ghc-options: -Wall -funbox-strict-fields -fno-warn-orphans


### PR DESCRIPTION
On my system, looking up a udev device of subsystem "backlight" gives me the device corresponding to `/sys/class/backlight/intel_backlight`
Until the next udev version is published, we're not filtering on events in udev, just inspecting all events received to see if they're from the "backlight" subsystem.

Perhaps ChannelWidget can / should be leveraged - maybe the stuff in PollingBar could be consolidated with that.
The stuff I added is missing the `void $ onWidgetUnrealize widget $ killThread processingThreadId` at the end, for instance. And also stuff to kill the data source thread - in this case, the one waiting on the udev monitor.

Fixes #321