### PR TITLE
Fix version of the dependency on the time library.

### DIFF
--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -79,7 +79,7 @@ library
                , stm
                , template-haskell
                , text
-               , time >= 1.4 && < 2.0
+               , time >= 1.8 && < 2.0
                , time-locale-compat >= 0.1 && < 0.2
                , time-units >= 1.0.0
                , transformers >= 0.3.0.0


### PR DESCRIPTION
`Data.Time.Clock.System`, as used by System.Taffybar.Information.Network
does not exist in versions of `time` previous to 1.8.