### PR TITLE
Removed Gtk2hs dependencies from System.Taffybar.Context

### DIFF
--- a/src/System/Taffybar/SimpleConfig.hs
+++ b/src/System/Taffybar/SimpleConfig.hs
@@ -23,8 +23,9 @@ import           Control.Monad.Trans.Class
 import           Data.List
 import           Data.Maybe
 import           Data.Unique
+import qualified GI.Gtk as Gtk
+import           GI.Gdk
 import           Graphics.UI.GIGtkStrut
-import           Graphics.UI.Gtk as Gtk
 import           System.Taffybar.Information.X11DesktopInfo
 import           System.Taffybar
 import qualified System.Taffybar.Context as BC (BarConfig(..))
@@ -135,7 +136,10 @@ simpleTaffybar :: SimpleTaffyConfig -> IO ()
 simpleTaffybar conf = dyreTaffybar $ toTaffyConfig conf
 
 getMonitorCount :: IO Int
-getMonitorCount = screenGetDefault >>= maybe (return 0) screenGetNMonitors
+getMonitorCount = do
+   screen <- screenGetDefault
+   monitors <- maybe (return 0) screenGetNMonitors screen
+   return (fromIntegral monitors)
 
 -- | Display a taffybar window on all monitors.
 useAllMonitors :: TaffyIO [Int]

--- a/src/System/Taffybar/Widget/Battery.hs
+++ b/src/System/Taffybar/Widget/Battery.hs
@@ -28,10 +28,8 @@ import           Data.GI.Gtk.Threading
 import           Data.Int (Int64)
 import qualified Data.Text as T
 import           GI.Gtk
-import qualified Graphics.UI.Gtk as Gtk2hs
 import           Prelude
 import           StatusNotifier.Tray (scalePixbufToSize)
-import           System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Context
 import           System.Taffybar.Information.Battery
 import           System.Taffybar.Widget.Generic.AutoSizeImage
@@ -89,8 +87,8 @@ formatBattInfo info fmt =
 -- charged/discharged.
 textBatteryNew
   :: String -- ^ Display format
-  -> TaffyIO Gtk2hs.Widget
-textBatteryNew format = fromGIWidget =<< do
+  -> TaffyIO Widget
+textBatteryNew format = do
   chan <- getDisplayBatteryChan
   ctx <- ask
   let getLabelText info =
@@ -106,8 +104,8 @@ textBatteryNew format = fromGIWidget =<< do
 themeLoadFlags :: [IconLookupFlags]
 themeLoadFlags = [IconLookupFlagsGenericFallback, IconLookupFlagsUseBuiltin]
 
-batteryIconNew :: TaffyIO Gtk2hs.Widget
-batteryIconNew = fromGIWidget =<< do
+batteryIconNew :: TaffyIO Widget
+batteryIconNew = do
   chan <- getDisplayBatteryChan
   ctx <- ask
   liftIO $ do

--- a/src/System/Taffybar/Widget/CPUMonitor.hs
+++ b/src/System/Taffybar/Widget/CPUMonitor.hs
@@ -16,7 +16,7 @@ module System.Taffybar.Widget.CPUMonitor where
 
 import Control.Monad.IO.Class
 import Data.IORef
-import Graphics.UI.Gtk
+import qualified GI.Gtk
 import System.Taffybar.Information.CPU2 (getCPUInfo)
 import System.Taffybar.Information.StreamInfo (getAccLoad)
 import System.Taffybar.Widget.Generic.PollingGraph
@@ -29,7 +29,7 @@ cpuMonitorNew
   => GraphConfig -- ^ Configuration data for the Graph.
   -> Double -- ^ Polling period (in seconds).
   -> String -- ^ Name of the core to watch (e.g. \"cpu\", \"cpu0\").
-  -> m Widget
+  -> m GI.Gtk.Widget
 cpuMonitorNew cfg interval cpu = liftIO $ do
     info <- getCPUInfo cpu
     sample <- newIORef info

--- a/src/System/Taffybar/Widget/CommandRunner.hs
+++ b/src/System/Taffybar/Widget/CommandRunner.hs
@@ -15,7 +15,7 @@
 module System.Taffybar.Widget.CommandRunner ( commandRunnerNew ) where
 
 import           Control.Monad.IO.Class
-import qualified Graphics.UI.Gtk as Gtk
+import qualified GI.Gtk
 import           System.Log.Logger
 import           System.Taffybar.Util
 import           System.Taffybar.Widget.Generic.PollingLabel
@@ -30,7 +30,7 @@ commandRunnerNew
   -> String -- ^ Command to execute. Should be in $PATH or an absolute path
   -> [String] -- ^ Command argument. May be @[]@
   -> String -- ^ If command fails this will be displayed.
-  -> m Gtk.Widget
+  -> m GI.Gtk.Widget
 commandRunnerNew interval cmd args defaultOutput =
   pollingLabelNew "" interval $
   runCommandWithDefault cmd args defaultOutput

--- a/src/System/Taffybar/Widget/Decorators.hs
+++ b/src/System/Taffybar/Widget/Decorators.hs
@@ -2,13 +2,15 @@ module System.Taffybar.Widget.Decorators where
 
 import           Control.Monad.IO.Class
 import qualified Graphics.UI.Gtk as Gtk
+import qualified GI.Gtk
+import System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Widget.Util
 
 -- | Wrap a widget with two container boxes. The inner box will have the class
 -- "InnerPad", and the outer box will have the class "OuterPad". These boxes can
 -- be used to add padding between the outline of the widget and its contents, or
 -- for the purpose of displaying a different background behind the widget.
-buildPadBox :: (Gtk.WidgetClass widget, MonadIO m) => widget -> m Gtk.Widget
+buildPadBox :: (Gtk.WidgetClass widget, MonadIO m) => widget -> m GI.Gtk.Widget
 buildPadBox contents = liftIO $ do
   innerBox <- Gtk.hBoxNew False 0
   outerBox <- Gtk.eventBoxNew
@@ -18,9 +20,9 @@ buildPadBox contents = liftIO $ do
   _ <- widgetSetClass outerBox "outer-pad"
   Gtk.widgetShow outerBox
   Gtk.widgetShow innerBox
-  return $ Gtk.toWidget outerBox
+  toGIWidget $ Gtk.toWidget outerBox
 
-buildContentsBox :: (Gtk.WidgetClass widget, MonadIO m) => widget -> m Gtk.Widget
+buildContentsBox :: (Gtk.WidgetClass widget, MonadIO m) => widget -> m GI.Gtk.Widget
 buildContentsBox widget = liftIO $ do
   contents <- Gtk.hBoxNew False 0
   Gtk.containerAdd contents widget

--- a/src/System/Taffybar/Widget/DiskIOMonitor.hs
+++ b/src/System/Taffybar/Widget/DiskIOMonitor.hs
@@ -16,7 +16,7 @@
 module System.Taffybar.Widget.DiskIOMonitor ( dioMonitorNew ) where
 
 import           Control.Monad.IO.Class
-import qualified Graphics.UI.Gtk as Gtk
+import qualified GI.Gtk
 import           System.Taffybar.Information.DiskIO ( getDiskTransfer )
 import           System.Taffybar.Widget.Generic.PollingGraph ( GraphConfig, pollingGraphNew )
 
@@ -29,7 +29,7 @@ dioMonitorNew
   => GraphConfig -- ^ Configuration data for the Graph.
   -> Double -- ^ Polling period (in seconds).
   -> String -- ^ Name of the disk or partition to watch (e.g. \"sda\", \"sdb1\").
-  -> m Gtk.Widget
+  -> m GI.Gtk.Widget
 dioMonitorNew cfg pollSeconds =
   pollingGraphNew cfg pollSeconds . probeDisk
 

--- a/src/System/Taffybar/Widget/FSMonitor.hs
+++ b/src/System/Taffybar/Widget/FSMonitor.hs
@@ -17,7 +17,7 @@
 module System.Taffybar.Widget.FSMonitor ( fsMonitorNew ) where
 
 import           Control.Monad.IO.Class
-import qualified Graphics.UI.Gtk as Gtk
+import qualified GI.Gtk
 import           System.Process ( readProcess )
 import           System.Taffybar.Widget.Generic.PollingLabel ( pollingLabelNew )
 
@@ -28,11 +28,11 @@ fsMonitorNew
   :: MonadIO m
   => Double -- ^ Polling interval (in seconds, e.g. 500)
   -> [String] -- ^ Names of the partitions to monitor (e.g. [\"\/\", \"\/home\"])
-  -> m Gtk.Widget
+  -> m GI.Gtk.Widget
 fsMonitorNew interval fsList = liftIO $ do
   label <- pollingLabelNew "" interval $ showFSInfo fsList
-  Gtk.widgetShowAll label
-  return $ Gtk.toWidget label
+  GI.Gtk.widgetShowAll label
+  GI.Gtk.toWidget label
 
 showFSInfo :: [String] -> IO String
 showFSInfo fsList = do

--- a/src/System/Taffybar/Widget/Generic/ChannelGraph.hs
+++ b/src/System/Taffybar/Widget/Generic/ChannelGraph.hs
@@ -4,11 +4,13 @@ import Control.Concurrent
 import Control.Monad
 import Control.Monad.IO.Class
 import Graphics.UI.Gtk
+import qualified GI.Gtk
+import System.Taffybar.Compat.GtkLibs
 import System.Taffybar.Widget.Generic.Graph
 
 channelGraphNew
   :: MonadIO m
-  => GraphConfig -> Chan a -> (a -> IO [Double]) -> m Widget
+  => GraphConfig -> Chan a -> (a -> IO [Double]) -> m GI.Gtk.Widget
 channelGraphNew config chan sampleBuilder = liftIO $ do
   (graphWidget, graphHandle) <- graphNew config
   _ <- on graphWidget realize $ do
@@ -17,4 +19,4 @@ channelGraphNew config chan sampleBuilder = liftIO $ do
          value <- readChan ourChan
          sampleBuilder value >>= graphAddSample graphHandle
        void $ on graphWidget unrealize $ killThread sampleThread
-  return graphWidget
+  toGIWidget graphWidget

--- a/src/System/Taffybar/Widget/Generic/Icon.hs
+++ b/src/System/Taffybar/Widget/Generic/Icon.hs
@@ -9,13 +9,15 @@ import Control.Concurrent ( forkIO, threadDelay )
 import Control.Exception as E
 import Control.Monad ( forever )
 import Graphics.UI.Gtk
+import qualified GI.Gtk
+import System.Taffybar.Compat.GtkLibs
 
 -- | Create a new widget that displays a static image
 --
 -- > iconImageWidgetNew path
 --
 -- returns a widget with icon at @path@.
-iconImageWidgetNew :: FilePath -> IO Widget
+iconImageWidgetNew :: FilePath -> IO GI.Gtk.Widget
 iconImageWidgetNew path = imageNewFromFile path >>= putInBox
 
 -- | Create a new widget that updates itself at regular intervals.  The
@@ -33,7 +35,7 @@ pollingIconImageWidgetNew
   :: FilePath -- ^ Initial file path of the icon
   -> Double -- ^ Update interval (in seconds)
   -> IO FilePath -- ^ Command to run to get the input filepath
-  -> IO Widget
+  -> IO GI.Gtk.Widget
 pollingIconImageWidgetNew path interval cmd = do
   icon <- imageNewFromFile path
   _ <- on icon realize $ do
@@ -46,12 +48,12 @@ pollingIconImageWidgetNew path interval cmd = do
     return ()
   putInBox icon
 
-putInBox :: WidgetClass child => child -> IO Widget
+putInBox :: WidgetClass child => child -> IO GI.Gtk.Widget
 putInBox icon = do
   box <- hBoxNew False 0
   boxPackStart box icon PackNatural 0
   widgetShowAll box
-  return $ toWidget box
+  toGIWidget $ toWidget box
 
 ignoreIOException :: IOException -> IO ()
 ignoreIOException _ = return ()

--- a/src/System/Taffybar/Widget/Generic/PollingBar.hs
+++ b/src/System/Taffybar/Widget/Generic/PollingBar.hs
@@ -13,20 +13,23 @@ module System.Taffybar.Widget.Generic.PollingBar (
 
 import Control.Concurrent
 import Control.Exception.Enclosed ( tryAny )
-import Graphics.UI.Gtk
+import qualified GI.Gtk
+import System.Taffybar.Compat.GtkLibs
 import System.Taffybar.Widget.Util ( backgroundLoop, drawOn )
 
 import System.Taffybar.Widget.Generic.VerticalBar
 
-verticalBarFromCallback :: BarConfig -> IO Double -> IO Widget
+verticalBarFromCallback :: BarConfig -> IO Double -> IO GI.Gtk.Widget
 verticalBarFromCallback cfg action = do
-  (drawArea, h) <- verticalBarNew cfg
-  drawOn drawArea $
+  (drawArea_, h) <- verticalBarNew cfg
+  drawArea <- fromGIWidget drawArea_
+  _ <- drawOn drawArea $
     backgroundLoop $ do
       esample <- tryAny action
       traverse (verticalBarSetPercent h) esample
+  return drawArea_
 
-pollingBarNew :: BarConfig -> Double -> IO Double -> IO Widget
+pollingBarNew :: BarConfig -> Double -> IO Double -> IO GI.Gtk.Widget
 pollingBarNew cfg pollSeconds action =
   verticalBarFromCallback cfg $ action <* delay
   where delay = threadDelay $ floor (pollSeconds * 1000000)

--- a/src/System/Taffybar/Widget/Generic/PollingGraph.hs
+++ b/src/System/Taffybar/Widget/Generic/PollingGraph.hs
@@ -16,12 +16,14 @@ import qualified Control.Exception.Enclosed as E
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Graphics.UI.Gtk
+import qualified GI.Gtk
+import System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Util
 import           System.Taffybar.Widget.Generic.Graph
 
 pollingGraphNew
   :: MonadIO m
-  => GraphConfig -> Double -> IO [Double] -> m Widget
+  => GraphConfig -> Double -> IO [Double] -> m GI.Gtk.Widget
 pollingGraphNew cfg pollSeconds action = liftIO $ do
   (graphWidget, graphHandle) <- graphNew cfg
 
@@ -33,4 +35,4 @@ pollingGraphNew cfg pollSeconds action = liftIO $ do
            Right sample -> graphAddSample graphHandle sample
        void $ on graphWidget unrealize $ killThread sampleThread
 
-  return graphWidget
+  toGIWidget graphWidget

--- a/src/System/Taffybar/Widget/Generic/PollingLabel.hs
+++ b/src/System/Taffybar/Widget/Generic/PollingLabel.hs
@@ -11,8 +11,6 @@ import           Control.Monad.IO.Class
 import           Data.GI.Gtk.Threading
 import qualified Data.Text as T
 import           GI.Gtk
-import qualified Graphics.UI.Gtk as Gtk2hs
-import           System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Util
 import           System.Taffybar.Widget.Util
 
@@ -34,7 +32,7 @@ pollingLabelNew
   => String -- ^ Initial value for the label
   -> Double -- ^ Update interval (in seconds)
   -> IO String -- ^ Command to run to get the input string
-  -> m Gtk2hs.Widget
+  -> m GI.Gtk.Widget
 pollingLabelNew initialString interval cmd =
   pollingLabelNewWithTooltip initialString interval $ (, Nothing) <$> cmd
 
@@ -43,9 +41,9 @@ pollingLabelNewWithTooltip
   => String -- ^ Initial value for the label
   -> Double -- ^ Update interval (in seconds)
   -> IO (String, Maybe String) -- ^ Command to run to get the input string
-  -> m Gtk2hs.Widget
+  -> m GI.Gtk.Widget
 pollingLabelNewWithTooltip initialString interval cmd =
-  liftIO $ fromGIWidget =<< do
+  liftIO $ do
     grid <- gridNew
     label <- labelNew $ Just $ T.pack initialString
 

--- a/src/System/Taffybar/Widget/Generic/VerticalBar.hs
+++ b/src/System/Taffybar/Widget/Generic/VerticalBar.hs
@@ -17,6 +17,8 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import qualified Graphics.Rendering.Cairo as C
 import           Graphics.UI.Gtk
+import qualified GI.Gtk
+import System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Widget.Util
 
 newtype VerticalBarHandle = VBH (MVar VerticalBarState)
@@ -159,7 +161,7 @@ drawBar mv drawArea = do
          return s
   renderBar (barPercent s) (barConfig s) w h
 
-verticalBarNew :: BarConfig -> IO (Widget, VerticalBarHandle)
+verticalBarNew :: BarConfig -> IO (GI.Gtk.Widget, VerticalBarHandle)
 verticalBarNew cfg = do
   drawArea <- drawingAreaNew
   mv <-
@@ -175,4 +177,5 @@ verticalBarNew cfg = do
   box <- hBoxNew False 1
   boxPackStart box drawArea PackGrow 0
   widgetShowAll box
-  return (toWidget box, VBH mv)
+  giBox <- toGIWidget $ toWidget box
+  return (giBox, VBH mv)

--- a/src/System/Taffybar/Widget/Layout.hs
+++ b/src/System/Taffybar/Widget/Layout.hs
@@ -25,8 +25,10 @@ module System.Taffybar.Widget.Layout
 
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Reader
+import qualified GI.Gtk
 import qualified Graphics.UI.Gtk as Gtk
 import qualified Graphics.UI.Gtk.Abstract.Widget as W
+import           System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Context
 import           System.Taffybar.Information.X11DesktopInfo
 import           System.Taffybar.Util
@@ -65,8 +67,8 @@ xLayoutProp = "_XMONAD_CURRENT_LAYOUT"
 
 -- | Create a new Layout widget that will use the given Pager as
 -- its source of events.
-layoutNew :: LayoutConfig -> TaffyIO Gtk.Widget
-layoutNew config = do
+layoutNew :: LayoutConfig -> TaffyIO GI.Gtk.Widget
+layoutNew config = toGIWidget =<< do
   ctx <- ask
   label <- lift $ Gtk.labelNew (Nothing :: Maybe String)
 

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -33,7 +33,6 @@ import qualified Data.Text as T
 import qualified GI.Gtk as Gtk
 import qualified Graphics.UI.Gtk as Gtk2hs
 import           System.Log.Logger
-import           System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Context
 import           System.Taffybar.DBus.Client.MPRIS2
 import           System.Taffybar.Information.MPRIS2
@@ -51,8 +50,8 @@ data MPRIS2PlayerWidget = MPRIS2PlayerWidget
   , playerGrid :: Gtk.Grid
   }
 
-mpris2New :: TaffyIO Gtk2hs.Widget
-mpris2New = asks sessionDBusClient >>= \client -> lift $ fromGIWidget =<< do
+mpris2New :: TaffyIO Gtk.Widget
+mpris2New = asks sessionDBusClient >>= \client -> lift $ do
   grid <- Gtk.gridNew
   vFillCenter grid
   playerWidgetsVar <- MV.newMVar []

--- a/src/System/Taffybar/Widget/NetworkGraph.hs
+++ b/src/System/Taffybar/Widget/NetworkGraph.hs
@@ -1,6 +1,6 @@
 module System.Taffybar.Widget.NetworkGraph where
 
-import Graphics.UI.Gtk
+import qualified GI.Gtk
 import System.Taffybar.Context
 import System.Taffybar.Hooks
 import System.Taffybar.Information.Network
@@ -12,7 +12,7 @@ logScale base maxValue value =
   logBase base (min value maxValue) / actualMax
     where actualMax = logBase base maxValue
 
-networkGraphNew :: GraphConfig -> Maybe [String] -> TaffyIO Widget
+networkGraphNew :: GraphConfig -> Maybe [String] -> TaffyIO GI.Gtk.Widget
 networkGraphNew config interfaces = do
   NetworkInfoChan chan <- getNetworkChan
   let filterFn = maybe (const True) (flip elem) interfaces

--- a/src/System/Taffybar/Widget/SNITray.hs
+++ b/src/System/Taffybar/Widget/SNITray.hs
@@ -15,11 +15,9 @@ import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Reader
 import qualified GI.Gtk
 import           Graphics.UI.GIGtkStrut
-import qualified Graphics.UI.Gtk as Gtk
 import qualified StatusNotifier.Host.Service as H
 import           StatusNotifier.Tray
 import           System.Posix.Process
-import           System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Context
 import           System.Taffybar.Widget.Util
 import           Text.Printf
@@ -37,7 +35,7 @@ getHost startWatcher = getStateDefault $ do
 
 -- | Build a new StatusNotifierItem tray that will share a host with any other
 -- trays that are constructed automatically
-sniTrayNewFromHost :: H.Host -> TaffyIO Gtk.Widget
+sniTrayNewFromHost :: H.Host -> TaffyIO GI.Gtk.Widget
 sniTrayNewFromHost host = do
   client <- asks sessionDBusClient
   lift $ do
@@ -53,11 +51,11 @@ sniTrayNewFromHost host = do
         }
     _ <- widgetSetClassGI tray "sni-tray"
     GI.Gtk.widgetShowAll tray
-    GI.Gtk.toWidget tray >>= fromGIWidget
+    GI.Gtk.toWidget tray
 
-sniTrayNew :: TaffyIO Gtk.Widget
+sniTrayNew :: TaffyIO GI.Gtk.Widget
 sniTrayNew = getHost False >>= sniTrayNewFromHost
 
-sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt :: TaffyIO Gtk.Widget
+sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt :: TaffyIO GI.Gtk.Widget
 sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt = getHost True >>= sniTrayNewFromHost
 

--- a/src/System/Taffybar/Widget/SimpleClock.hs
+++ b/src/System/Taffybar/Widget/SimpleClock.hs
@@ -16,6 +16,8 @@ import qualified Data.Time.Clock as Clock
 import           Data.Time.Format
 import           Data.Time.LocalTime
 import qualified Data.Time.Locale.Compat as L
+import qualified GI.Gtk
+import System.Taffybar.Compat.GtkLibs
 import           Graphics.UI.Gtk
 
 import           System.Taffybar.Widget.Generic.PollingLabel
@@ -55,9 +57,9 @@ toggleCalendar w c = do
 -- | Create the widget. I recommend passing @Nothing@ for the TimeLocale
 -- parameter. The format string can include Pango markup
 -- (http://developer.gnome.org/pango/stable/PangoMarkupFormat.html).
-textClockNew :: MonadIO m => Maybe L.TimeLocale -> String -> Double -> m Widget
-textClockNew userLocale =
-  textClockNewWith cfg
+textClockNew :: MonadIO m => Maybe L.TimeLocale -> String -> Double -> m GI.Gtk.Widget
+textClockNew userLocale s t =
+  textClockNewWith cfg s t >>= toGIWidget
   where
     cfg = defaultClockConfig { clockTimeLocale = userLocale }
 
@@ -98,7 +100,7 @@ textClockNewWith cfg fmt updateSeconds = liftIO $ do
   let ti = TimeInfo { getTZ = maybe systemGetTZ return userZone
                     , getLocale = maybe (return L.defaultTimeLocale) return userLocale
                     }
-  l    <- pollingLabelNew "" updateSeconds (getCurrentTime' ti fmt)
+  l    <- pollingLabelNew "" updateSeconds (getCurrentTime' ti fmt) >>= fromGIWidget
   ebox <- eventBoxNew
   containerAdd ebox l
   eventBoxSetVisibleWindow ebox False

--- a/src/System/Taffybar/Widget/Systray.hs
+++ b/src/System/Taffybar/Widget/Systray.hs
@@ -3,10 +3,12 @@
 module System.Taffybar.Widget.Systray {-# DEPRECATED "Use SNITray instead" #-} ( systrayNew ) where
 
 import Control.Monad.IO.Class
+import qualified GI.Gtk
+import System.Taffybar.Compat.GtkLibs
 import Graphics.UI.Gtk
 import Graphics.UI.Gtk.Misc.TrayManager
 
-systrayNew :: MonadIO m => m Widget
+systrayNew :: MonadIO m => m GI.Gtk.Widget
 systrayNew = liftIO $ do
   box <- hBoxNew False 5
 
@@ -19,4 +21,4 @@ systrayNew = liftIO $ do
     boxPackStart box w PackNatural 0
 
   widgetShowAll box
-  return (toWidget box)
+  toGIWidget (toWidget box)

--- a/src/System/Taffybar/Widget/Text/CPUMonitor.hs
+++ b/src/System/Taffybar/Widget/Text/CPUMonitor.hs
@@ -4,16 +4,16 @@ import Text.Printf ( printf )
 import qualified Text.StringTemplate as ST
 import System.Taffybar.Information.CPU
 import System.Taffybar.Widget.Generic.PollingLabel ( pollingLabelNew )
-import qualified Graphics.UI.Gtk as Gtk
+import qualified GI.Gtk
 
 -- | Creates a simple textual CPU monitor. It updates once every polling
 -- period (in seconds).
 textCpuMonitorNew :: String -- ^ Format. You can use variables: $total$, $user$, $system$
                   -> Double -- ^ Polling period (in seconds)
-                  -> IO Gtk.Widget
+                  -> IO GI.Gtk.Widget
 textCpuMonitorNew fmt period = do
   label <- pollingLabelNew fmt period callback
-  Gtk.widgetShowAll label
+  GI.Gtk.widgetShowAll label
   return label
   where
     callback = do

--- a/src/System/Taffybar/Widget/Text/MemoryMonitor.hs
+++ b/src/System/Taffybar/Widget/Text/MemoryMonitor.hs
@@ -3,16 +3,16 @@ module System.Taffybar.Widget.Text.MemoryMonitor (textMemoryMonitorNew) where
 import qualified Text.StringTemplate as ST
 import System.Taffybar.Information.Memory
 import System.Taffybar.Widget.Generic.PollingLabel ( pollingLabelNew )
-import qualified Graphics.UI.Gtk as Gtk
+import qualified GI.Gtk
 
 -- | Creates a simple textual memory monitor. It updates once every polling
 -- period (in seconds).
 textMemoryMonitorNew :: String -- ^ Format. You can use variables: "used", "total", "free", "buffer", "cache", "rest", "used".
                      -> Double -- ^ Polling period in seconds.
-                     -> IO Gtk.Widget
+                     -> IO GI.Gtk.Widget
 textMemoryMonitorNew fmt period = do
     label <- pollingLabelNew fmt period callback
-    Gtk.widgetShowAll label
+    GI.Gtk.widgetShowAll label
     return label
     where
       callback = do

--- a/src/System/Taffybar/Widget/Text/NetworkMonitor.hs
+++ b/src/System/Taffybar/Widget/Text/NetworkMonitor.hs
@@ -5,8 +5,6 @@ import           Control.Monad.Trans.Class
 import           Data.GI.Gtk.Threading
 import qualified Data.Text as T
 import           GI.Gtk
-import qualified Graphics.UI.Gtk as Gtk2hs
-import           System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Context
 import           System.Taffybar.Hooks
 import           System.Taffybar.Information.Network
@@ -58,8 +56,8 @@ toAuto prec value = printf "%.*f%s" p v unit
         p :: Int
         p = max 0 $ floor $ fromIntegral prec - logBase 10 v
 
-networkMonitorNew :: String -> Maybe [String] -> TaffyIO Gtk2hs.Widget
-networkMonitorNew template interfaces = fromGIWidget =<< do
+networkMonitorNew :: String -> Maybe [String] -> TaffyIO GI.Gtk.Widget
+networkMonitorNew template interfaces = do
   NetworkInfoChan chan <- getNetworkChan
   let filterFn = maybe (const True) (flip elem) interfaces
   label <- lift $ labelNew Nothing

--- a/src/System/Taffybar/Widget/Weather.hs
+++ b/src/System/Taffybar/Widget/Weather.hs
@@ -68,6 +68,7 @@ module System.Taffybar.Widget.Weather
   ) where
 
 import Control.Monad.IO.Class
+import qualified GI.Gtk
 import Graphics.UI.Gtk
 import qualified Network.Browser as Browser
 import Network.HTTP
@@ -294,7 +295,7 @@ defaultWeatherConfig station =
 -- | Create a periodically-updating weather widget that polls NOAA.
 weatherNew :: WeatherConfig -- ^ Configuration to render
            -> Double     -- ^ Polling period in _minutes_
-           -> IO Widget
+           -> IO GI.Gtk.Widget
 weatherNew cfg delayMinutes = do
   let url = printf "%s/%s.TXT" baseUrl (weatherStation cfg)
       getter = getWeather (weatherProxy cfg) url
@@ -309,7 +310,7 @@ weatherCustomNew
   -> String -- ^ Weather template
   -> WeatherFormatter -- ^ Weather formatter
   -> Double -- ^ Polling period in _minutes_
-  -> m Widget
+  -> m GI.Gtk.Widget
 weatherCustomNew getter labelTpl tooltipTpl formatter delayMinutes = liftIO $ do
   let labelTpl' = newSTMP labelTpl
       tooltipTpl' = newSTMP tooltipTpl
@@ -317,5 +318,5 @@ weatherCustomNew getter labelTpl tooltipTpl formatter delayMinutes = liftIO $ do
   l <- pollingLabelNewWithTooltip "N/A" (delayMinutes * 60)
        (getCurrentWeather getter labelTpl' tooltipTpl' formatter)
 
-  widgetShowAll l
+  GI.Gtk.widgetShowAll l
   return l

--- a/src/System/Taffybar/Widget/Windows.hs
+++ b/src/System/Taffybar/Widget/Windows.hs
@@ -31,7 +31,6 @@ import           Data.GI.Gtk.Threading
 import qualified Data.Text as T
 import qualified GI.Gtk as Gtk
 import qualified Graphics.UI.Gtk as Gtk2hs
-import           System.Taffybar.Compat.GtkLibs
 import           System.Taffybar.Context
 import           System.Taffybar.Information.EWMHDesktopInfo
 import           System.Taffybar.Util
@@ -75,8 +74,8 @@ defaultWindowsConfig =
 
 -- | Create a new Windows widget that will use the given Pager as
 -- its source of events.
-windowsNew :: WindowsConfig -> TaffyIO Gtk2hs.Widget
-windowsNew config = (`widgetSetClass` "windows") =<< fromGIWidget =<< do
+windowsNew :: WindowsConfig -> TaffyIO Gtk.Widget
+windowsNew config = do
   label <- lift $ Gtk.labelNew Nothing
 
   let setLabelTitle title = lift $ postGUIASync $ Gtk.labelSetMarkup label (T.pack title)
@@ -88,10 +87,12 @@ windowsNew config = (`widgetSetClass` "windows") =<< fromGIWidget =<< do
   context <- ask
 
   labelWidget <- Gtk.toWidget label
-  dynamicMenuNew
+  menu <- dynamicMenuNew
     DynamicMenuConfig { dmClickWidget = labelWidget
                       , dmPopulateMenu = flip runReaderT context . fillMenu config
                       }
+
+  widgetSetClassGI menu (T.pack "windows")
 
 -- | Populate the given menu widget with the list of all currently open windows.
 fillMenu :: Gtk.IsMenuShell a => WindowsConfig -> a -> ReaderT Context IO ()

--- a/src/System/Taffybar/Widget/Workspaces.hs
+++ b/src/System/Taffybar/Widget/Workspaces.hs
@@ -300,8 +300,8 @@ addWidget controller = do
       else Gtk.containerAdd hbox workspaceWidget
     Gtk.containerAdd cont hbox
 
-workspacesNew :: WorkspacesConfig -> TaffyIO Gtk.Widget
-workspacesNew cfg = ask >>= \tContext -> lift $ do
+workspacesNew :: WorkspacesConfig -> TaffyIO GI.Gtk.Widget
+workspacesNew cfg = toGIWidget =<< (ask >>= \tContext -> lift $ do
   cont <- Gtk.hBoxNew False (widgetGap cfg)
   controllersRef <- MV.newMVar M.empty
   workspacesRef <- MV.newMVar M.empty
@@ -326,7 +326,7 @@ workspacesNew cfg = ask >>= \tContext -> lift $ do
         mapM_ unsubscribe [iconSubscription, workspaceSubscription]
   _ <- Gtk.on cont W.unrealize doUnsubscribe
   _ <- widgetSetClass cont "workspaces"
-  return $ Gtk.toWidget cont
+  return $ Gtk.toWidget cont)
 
 updateAllWorkspaceWidgets :: WorkspacesIO ()
 updateAllWorkspaceWidgets = do
@@ -473,7 +473,7 @@ buildContentsController constructors ws = do
   tempController <- lift $ do
     cons <- Gtk.hBoxNew False 0
     mapM_ (Gtk.containerAdd cons . getWidget) controllers
-    outerBox <- buildPadBox cons
+    outerBox <- fromGIWidget =<< buildPadBox cons
     _ <- widgetSetClass cons "contents"
     return
       WorkspaceContentsController

--- a/src/System/Taffybar/Widget/XDGMenu/MenuWidget.hs
+++ b/src/System/Taffybar/Widget/XDGMenu/MenuWidget.hs
@@ -26,6 +26,8 @@ where
 import Control.Monad
 import Control.Monad.IO.Class
 import Graphics.UI.Gtk hiding (Menu)
+import qualified GI.Gtk
+import System.Taffybar.Compat.GtkLibs
 import System.Directory
 import System.FilePath.Posix
 import System.Process
@@ -117,13 +119,13 @@ setIcon item (Just iconName) = do
 -- | Create a new XDG Menu Widget.
 menuWidgetNew :: MonadIO m => Maybe String -- ^ menu name, must end with a dash,
                               -- e.g. "mate-" or "gnome-"
-              -> m Widget
+              -> m GI.Gtk.Widget
 menuWidgetNew mMenuPrefix = liftIO $ do
   mb <- menuBarNew
   m <- buildMenu mMenuPrefix
   addMenu mb m
   widgetShowAll mb
-  return (toWidget mb)
+  toGIWidget (toWidget mb)
 
 -- -- | Show XDG Menu Widget in a standalone frame.
 -- testMenuWidget :: IO ()


### PR DESCRIPTION
This removes, as far as I can see, all references to Gtk2hs in Context.

This does raise some deprecation warnings related to hBox.