### PR TITLE
the glib in version 2.0.17 was missing

### DIFF
--- a/stack.yaml.example
+++ b/stack.yaml.example
@@ -20,6 +20,7 @@ extra-deps:
 - gi-gtk-hs-0.3.6.1
 - gi-pango-1.0.16
 - gi-xlib-2.0.2
+- gi-glib-2.0.17
 - gio-0.13.4.1
 - gtk-sni-tray-0.1.4.0
 - gtk-strut-0.1.2.1


### PR DESCRIPTION
the glib in version 2.0.17 was missing when i tried to install with the quickstartscript