### PR TITLE
Bugfix: Expire time in millisecond is wrongly taken as second.

### DIFF
--- a/src/System/Taffybar/Widget/FreedesktopNotifications.hs
+++ b/src/System/Taffybar/Widget/FreedesktopNotifications.hs
@@ -194,7 +194,7 @@ startTimeoutThread :: NotifyState -> Notification -> IO ()
 startTimeoutThread s Notification {..} = case noteExpireTimeout of
   Nothing -> return ()
   Just timeout -> void $ forkIO $ do
-    threadDelay (fromIntegral timeout * 10^(6 :: Int))
+    threadDelay (fromIntegral timeout * 10^(3 :: Int))
     notePurge s noteId
     wakeupDisplayThread s
 


### PR DESCRIPTION
Per https://developer.gnome.org/notification-spec/, expire timeout value
passed in is millisecond. Since threadDelay takes microsecond, the
multiply times should be 10^3, instead of 10^6.