### PR TITLE
Build with ghc-8.2.2 using Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .stack-work
 .cabal-sandbox
 cabal.sandbox.config
+/result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,38 @@
+# You can build this repository by running:
+#   $ nix-build
+
+{
+pkgs_path ? ./nix/nixpkgs.nix
+}:
+
+let
+  overlay = import ./nix/overlay.nix;
+  pkgs = import pkgs_path {
+    config = {};
+    overlays = [ overlay ];
+  };
+  filter =  import ./nix/filter.nix {inherit (pkgs)lib;};
+  haskellPackages = pkgs.haskell.packages.ghc822.override {
+    overrides = self: super: {
+      taffybar = with pkgs.haskell.lib;
+        ((addPkgconfigDepend (disableLibraryProfiling (dontCheck (dontHaddock
+          ( pkgs.haskell.packages.ghc822.callCabal2nix
+              "taffybar"
+              (builtins.path { name = "taffybar"; inherit filter; path = ./.; } )
+              { }
+          )))) pkgs.gtk3).overrideAttrs (_: { strictDeps = true; }));
+        };
+  };
+  ghcWithTaffybar = haskellPackages.ghcWithPackages (p: with p; [taffybar]);
+
+in
+
+  pkgs.stdenv.mkDerivation {
+    name = "taffy-ghc-env";
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    buildCommand = ''
+      mkdir -p $out/bin
+      makeWrapper ${ghcWithTaffybar}/bin/taffybar $out/bin/taffybar \
+        --set NIX_GHC "${ghcWithTaffybar}/bin/ghc"
+    '';
+  }

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,8 @@
 #   $ nix-build
 
 {
-pkgs_path ? ./nix/nixpkgs.nix
+  pkgs_path ? ./nix/nixpkgs.nix
+, compiler ? "ghc822"
 }:
 
 let
@@ -12,11 +13,11 @@ let
     overlays = [ overlay ];
   };
   filter =  import ./nix/filter.nix {inherit (pkgs)lib;};
-  haskellPackages = pkgs.haskell.packages.ghc822.override {
+  haskellPackages = pkgs.haskell.packages.${compiler}.override {
     overrides = self: super: {
       taffybar = with pkgs.haskell.lib;
         (addPkgconfigDepend (disableLibraryProfiling (dontCheck (dontHaddock
-          ( pkgs.haskell.packages.ghc822.callCabal2nix
+          ( pkgs.haskell.packages.${compiler}.callCabal2nix
               "taffybar"
               (builtins.path { name = "taffybar"; inherit filter; path = ./.; } )
               { }

--- a/default.nix
+++ b/default.nix
@@ -15,12 +15,12 @@ let
   haskellPackages = pkgs.haskell.packages.ghc822.override {
     overrides = self: super: {
       taffybar = with pkgs.haskell.lib;
-        ((addPkgconfigDepend (disableLibraryProfiling (dontCheck (dontHaddock
+        (addPkgconfigDepend (disableLibraryProfiling (dontCheck (dontHaddock
           ( pkgs.haskell.packages.ghc822.callCabal2nix
               "taffybar"
               (builtins.path { name = "taffybar"; inherit filter; path = ./.; } )
               { }
-          )))) pkgs.gtk3).overrideAttrs (_: { strictDeps = true; }));
+          )))) pkgs.gtk3);
         };
   };
   ghcWithTaffybar = haskellPackages.ghcWithPackages (p: with p; [taffybar]);

--- a/nix/.nixpkgs.json
+++ b/nix/.nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/nixos/nixpkgs.git",
+  "rev": "903306a74d31542935f6cd32758d5df2359b3b98",
+  "date": "2018-08-23T09:40:12+02:00",
+  "sha256": "1wlch8lfc1x5xawqc630mg9n5586yv4d1nnvzcm95gq0yq779y97",
+  "fetchSubmodules": true
+}

--- a/nix/filter.nix
+++ b/nix/filter.nix
@@ -1,0 +1,17 @@
+# Filter source files that are not part of the build
+{ lib }:
+
+path: type:
+
+let
+  baseName = baseNameOf (toString path);
+in
+     type != "symlink"
+  && baseName != ".stack-work"
+  && baseName != ".git"
+  && baseName != "default.nix"
+  && baseName != "README.md"
+  && baseName != "CHANGELOG.md"
+  && baseName != "Dockerfile"
+  && baseName != "Dockerfile.base"
+  && ! lib.hasSuffix ".example" baseName

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,7 @@
+let
+  nixpkgs = builtins.fromJSON (builtins.readFile ./.nixpkgs.json);
+in
+import (fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/${nixpkgs.rev}.tar.gz";
+  inherit (nixpkgs) sha256;
+})

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,10 @@
+self: super:
+
+{
+  haskell = super.haskell // { packages = super.haskell.packages // { ghc822 = super.haskell.packages.ghc822.override {
+     overrides =  hpkgs: _: {
+       haskell-gi-overloading = hpkgs.haskell-gi-overloading_0_0;
+     };
+  };};};
+
+}

--- a/stack-11.22.yaml
+++ b/stack-11.22.yaml
@@ -1,0 +1,55 @@
+packages:
+- '.'
+extra-deps:
+- X11-xft-0.3.1
+- dbus-1.0.1
+- dbus-hslogger-0.1.0.1
+- gi-dbusmenu-0.4.1
+- gi-dbusmenugtk3-0.4.1
+- gi-gdk-3.0.15
+- gi-gdkpixbuf-2.0.16
+- gi-gdkx11-3.0.2
+- gi-gio-2.0.18
+- gi-gtk-3.0.21
+- gi-gtk-hs-0.3.6.1
+- gi-glib-2.0.17
+- gi-pango-1.0.16
+- gi-xlib-2.0.2
+- gio-0.13.4.1
+- gtk-sni-tray-0.1.5.0
+- gtk-strut-0.1.2.1
+- gtk-traymanager-1.0.1
+- gtk3-0.14.9
+- haskell-gi-0.21.2
+- haskell-gi-base-0.21.1
+- libxml-sax-0.7.5
+- rate-limit-1.1.1
+- spool-0.1
+- status-notifier-item-0.3.0.0
+- time-units-1.0.0
+- xml-helpers-1.0.0
+resolver: lts-11.22
+allow-newer: true
+system-ghc: true
+skip-ghc-check: true
+nix:
+  enable: true
+  packages:
+    - cairo
+    - gcc
+    - gnome2.pango
+    - gobjectIntrospection
+    - gtk3
+    - hicolor-icon-theme
+    - libdbusmenu-glib
+    - libdbusmenu-gtk3
+    - libxml2
+    - numix-icon-theme-circle
+    - pkgconfig
+    - x11
+    - xorg.libX11
+    - xorg.libXext
+    - xorg.libXinerama
+    - xorg.libXrandr
+    - xorg.libXrender
+    - zlib

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-8.2.yaml
+stack-11.22.yaml


### PR DESCRIPTION
This is not ready to be merged.

I would like to discuss this PR to get feedback and help.

This PR allows me to install `Taffybar` compiled with ghc-8.2.2. This is necessary because of https://github.com/taffybar/taffybar/issues/358.

You can try it out in nixos (and I guess also with nix and other linux distro) by using this command:
```
nix-env -i -f https://github.com/pierrer/taffybar/tarball/20584dafc952fbe5ee36136e0492500749ea7faa
```

It is going to take quite a while because a lot of the dependencies are not in the nixos default binary cache.

One issue remains. It works on the stable nixos channel (18.03) but it won't work so well when I use the unstable channel (18.09). In `18.09` it completes the building process without problem but Taffybar will fail to recompile the user configuration. It complains that it can't find the imported taffybar modules.

As a bonus, I would also like to speed up the build/compilation process (by disabling profiling globally, using `justStaticExecutables´, ...). Any idea or suggestion welcomed.

When I am happy about the workflow I will probably push it to [cachix](https://cachix.org/)

Thanks for your help and feedback.