### PR TITLE
markupEscapeText expects length in bytes, not characters

### DIFF
--- a/src/System/Taffybar/Widget/FreedesktopNotifications.hs
+++ b/src/System/Taffybar/Widget/FreedesktopNotifications.hs
@@ -121,8 +121,8 @@ notify s appName replaceId _ summary body _ _ timeout = do
                            Nothing -> Just timeout
                            Just maxTimeout -> Just (min maxTimeout timeout)
 
-  escapedSummary <- markupEscapeText summary (fromIntegral $ T.length summary)
-  escapedBody <- markupEscapeText body (fromIntegral $ T.length body)
+  escapedSummary <- markupEscapeText summary (-1)
+  escapedBody <- markupEscapeText body (-1)
   let n = Notification { noteAppName = appName
                        , noteReplaceId = replaceId
                        , noteSummary = escapedSummary

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -144,7 +144,7 @@ mpris2New = asks sessionDBusClient >>= \client -> lift $ do
 
 playingText :: MonadIO m => Int -> Int -> NowPlaying -> m T.Text
 playingText artistMax songMax NowPlaying {npArtists = artists, npTitle = title} =
-  G.markupEscapeText formattedText (fromIntegral $ T.length formattedText)
+  G.markupEscapeText formattedText (-1)
   where formattedText = T.pack $ printf
            "%s - %s"
            (truncateString artistMax $ intercalate "," artists)

--- a/src/System/Taffybar/Widget/Weather.hs
+++ b/src/System/Taffybar/Widget/Weather.hs
@@ -241,12 +241,12 @@ getCurrentWeather getter labelTpl tooltipTpl formatter = do
         DefaultWeatherFormatter -> do
           let rawLabel = T.pack $ defaultFormatter labelTpl wi
           let rawTooltip = T.pack $ defaultFormatter tooltipTpl wi
-          lbl <- markupEscapeText rawLabel (fromIntegral $ T.length rawLabel)
-          tooltip <- markupEscapeText rawTooltip (fromIntegral $ T.length rawTooltip)
+          lbl <- markupEscapeText rawLabel (-1)
+          tooltip <- markupEscapeText rawTooltip (-1)
           return (lbl, Just tooltip)
         WeatherFormatter f -> do
           let rawLabel = T.pack $ f wi
-          lbl <- markupEscapeText rawLabel (fromIntegral $ T.length rawLabel)
+          lbl <- markupEscapeText rawLabel (-1)
           return (lbl, Just lbl)
     Left err -> do
       putStrLn err


### PR DESCRIPTION
When text contains multi-byte characters, the length is undercalculated
for the `markupEscapeText` function, which expects the length of the
text in bytes.  This results in some labels being prematurely truncated.

I began replacing calls to `Data.Text.length` with
`Data.ByteString.length` when I read that `markupEscapeText` can also
accept the length as `-1` when the text is null-terminated, which I have
found to be the case in all the places it's used.  This approach doesn't
add a new dependency on the `bytestring` package and may be less
expensive.

Closes #416 