### PR TITLE
windows: Fix over-escaped text in menu labels

### DIFF
--- a/src/System/Taffybar/Widget/Windows.hs
+++ b/src/System/Taffybar/Widget/Windows.hs
@@ -40,11 +40,12 @@ data WindowsConfig = WindowsConfig
 defaultGetMenuLabel :: X11Window -> TaffyIO T.Text
 defaultGetMenuLabel window = do
   windowString <- runX11Def "(nameless window)" (getWindowTitle window)
-  markupEscapeText (T.pack windowString) $ fromIntegral $ length windowString
+  return $ T.pack windowString
 
 defaultGetActiveLabel :: TaffyIO T.Text
-defaultGetActiveLabel = fromMaybe "" <$>
-  (runX11Def Nothing getActiveWindow >>= traverse defaultGetMenuLabel)
+defaultGetActiveLabel = do
+  label <- fromMaybe "" <$> (runX11Def Nothing getActiveWindow >>= traverse defaultGetMenuLabel)
+  markupEscapeText label (-1)
 
 truncatedGetActiveLabel :: Int -> TaffyIO T.Text
 truncatedGetActiveLabel maxLength =


### PR DESCRIPTION
It was observed in #379 that the window widget menu labels appear to be
wrongly escaped while the active label is OK.  This appears to be
because the GTK menuitem labels don't support markup, or at least
there seems to be no way to access the internal label to enable the
markup property.  Because of this limitation, there is no need to escape
the menuitem label text, as implemented in this change.