### PR TITLE
Remove unnecessary, leaky Chan duplication

### DIFF
--- a/src/System/Taffybar/Widget/Generic/ChannelGraph.hs
+++ b/src/System/Taffybar/Widget/Generic/ChannelGraph.hs
@@ -12,9 +12,8 @@ channelGraphNew
 channelGraphNew config chan sampleBuilder = do
   (graphWidget, graphHandle) <- graphNew config
   _ <- onWidgetRealize graphWidget $ do
-       ourChan <- dupChan chan
        sampleThread <- forkIO $ forever $ do
-         value <- readChan ourChan
+         value <- readChan chan
          sampleBuilder value >>= graphAddSample graphHandle
        void $ onWidgetUnrealize graphWidget $ killThread sampleThread
   return graphWidget

--- a/src/System/Taffybar/Widget/Generic/ChannelWidget.hs
+++ b/src/System/Taffybar/Widget/Generic/ChannelWidget.hs
@@ -8,9 +8,8 @@ import GI.Gtk
 channelWidgetNew :: (MonadIO m, IsWidget w) => w -> Chan a -> (a -> IO ()) -> m w
 channelWidgetNew widget channel updateWidget = do
   void $ onWidgetRealize widget $ do
-    ourChan <- dupChan channel
     processingThreadId <- forkIO $ forever $
-      readChan ourChan >>= updateWidget
+      readChan channel >>= updateWidget
     void $ onWidgetUnrealize widget $ killThread processingThreadId
   widgetShowAll widget
   return widget


### PR DESCRIPTION
Related to #352:
The `dupChan` in `channelWidgetNew` and `channelGraphNew` are
unnecessary since all widgets so created (battery and network) create
new channels.  These are then duplicated and the original is left
hanging, accumulating unread writes.  This eliminates a big space leak,
especially for the battery widgets.