### PR TITLE
Allow CSS stylesheet to be specified from TaffybarConfig

### DIFF
--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -154,8 +154,8 @@ getDefaultConfigFile name = do
   dataDir <- getDataDir
   return (dataDir </> name)
 
-startCSS :: IO Gtk.CssProvider
-startCSS = do
+startCSS :: Maybe FilePath -> IO Gtk.CssProvider
+startCSS configCssPath = do
   -- Override the default GTK theme path settings.  This causes the
   -- bar (by design) to ignore the real GTK theme and just use the
   -- provided minimal theme to set the background and text colors.
@@ -165,6 +165,7 @@ startCSS = do
         doesFileExist filePath >>=
         flip when (Gtk.cssProviderLoadFromPath taffybarProvider (T.pack filePath))
   loadIfExists =<< getDefaultConfigFile "taffybar.css"
+  mapM_ loadIfExists configCssPath
   loadIfExists =<< getUserConfigFile "taffybar" "taffybar.css"
   Just scr <- Gdk.screenGetDefault
   Gtk.styleContextAddProviderForScreen scr taffybarProvider 800
@@ -181,7 +182,7 @@ startTaffybar config = do
   _ <- initThreads
   _ <- Gtk.init Nothing
   GIThreading.setCurrentThreadAsGUIThread
-  _ <- startCSS
+  _ <- startCSS (cssPath config)
   _ <- buildContext config
 
   Gtk.main

--- a/src/System/Taffybar/Context.hs
+++ b/src/System/Taffybar/Context.hs
@@ -84,6 +84,7 @@ data TaffybarConfig = TaffybarConfig
   { dbusClientParam :: Maybe DBus.Client
   , startupHook :: TaffyIO ()
   , getBarConfigsParam :: BarConfigGetter
+  , cssPath :: Maybe FilePath
   , errorMsg :: Maybe String
   }
 
@@ -96,6 +97,7 @@ defaultTaffybarConfig = TaffybarConfig
   { dbusClientParam = Nothing
   , startupHook = return ()
   , getBarConfigsParam = return []
+  , cssPath = Nothing
   , errorMsg = Nothing
   }
 

--- a/src/System/Taffybar/SimpleConfig.hs
+++ b/src/System/Taffybar/SimpleConfig.hs
@@ -29,8 +29,8 @@ import           GI.Gdk
 import           Graphics.UI.GIGtkStrut
 import           System.Taffybar.Information.X11DesktopInfo
 import           System.Taffybar
-import qualified System.Taffybar.Context as BC (BarConfig(..))
-import           System.Taffybar.Context hiding (BarConfig(..))
+import qualified System.Taffybar.Context as BC (BarConfig(..), TaffybarConfig(..))
+import           System.Taffybar.Context hiding (BarConfig(..), cssPath)
 import           System.Taffybar.Util
 
 -- | The side of the monitor at which taffybar should be displayed.
@@ -57,6 +57,9 @@ data SimpleTaffyConfig = SimpleTaffyConfig
   , centerWidgets :: [TaffyIO Gtk.Widget]
   -- | Widget constructors whose results are placed at the end of the bar
   , endWidgets :: [TaffyIO Gtk.Widget]
+  -- | Optional path to CSS stylesheet (loaded in addition to stylesheet found
+  -- in XDG data directory).
+  , cssPath :: Maybe FilePath
   }
 
 -- | Sensible defaults for most of the fields of 'SimpleTaffyConfig'. You'll
@@ -72,6 +75,7 @@ defaultSimpleTaffyConfig = SimpleTaffyConfig
   , startWidgets = []
   , centerWidgets = []
   , endWidgets = []
+  , cssPath = Nothing
   }
 
 toStrutConfig :: SimpleTaffyConfig -> Int -> StrutConfig
@@ -108,7 +112,10 @@ toBarConfig config monitor = do
 newtype SimpleBarConfigs = SimpleBarConfigs (MV.MVar [(Int, BC.BarConfig)])
 
 toTaffyConfig :: SimpleTaffyConfig -> TaffybarConfig
-toTaffyConfig conf = defaultTaffybarConfig { getBarConfigsParam = configGetter }
+toTaffyConfig conf =
+    defaultTaffybarConfig { getBarConfigsParam = configGetter
+                          , BC.cssPath = cssPath conf
+                          }
   where
     configGetter = do
       SimpleBarConfigs configsVar <-


### PR DESCRIPTION
This makes it easier to package a taffybar configuration into a
self-contained Cabal package.