### PR TITLE
Fix scotty version bounds

### DIFF
--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -74,7 +74,7 @@ library
                , rate-limit >= 1.1.1
                , regex-compat
                , safe >= 0.3 && < 1
-               , scotty >= 11.2 && < 12.0
+               , scotty >= 0.11.2 && < 0.12.0
                , split >= 0.1.4.2
                , status-notifier-item >= 0.3.0.1
                , stm


### PR DESCRIPTION
When trying to install taffybar with `stack` I encountered this error
```
➜  ~ stack install taffybar

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for taffybar-3.1.0:
    scotty-0.11.3 from stack configuration does not match >=11.2 && <12.0
needed since taffybar is a build target.
```
Checking the latest version of `scotty` on Hackage, it looks like http://hackage.haskell.org/package/scotty-0.11.3 is the latest.

Thanks for keeping `taffybar` great!