### PR TITLE
add CSS class to `Layout`

### DIFF
--- a/src/System/Taffybar/Widget/Layout.hs
+++ b/src/System/Taffybar/Widget/Layout.hs
@@ -31,6 +31,7 @@ import           GI.Gdk
 import           System.Taffybar.Context
 import           System.Taffybar.Information.X11DesktopInfo
 import           System.Taffybar.Util
+import           System.Taffybar.Widget.Util
 
 -- $usage
 --
@@ -69,6 +70,8 @@ layoutNew :: LayoutConfig -> TaffyIO Gtk.Widget
 layoutNew config = do
   ctx <- ask
   label <- lift $ Gtk.labelNew (Nothing :: Maybe T.Text)
+  _ <- widgetSetClassGI label "layout-label"
+  
 
   -- This callback is run in a separate thread and needs to use
   -- postGUIASync

--- a/src/System/Taffybar/Widget/Layout.hs
+++ b/src/System/Taffybar/Widget/Layout.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      : System.Taffybar.Widget.Layout


### PR DESCRIPTION
Gives the label in `Layout` the class `layout-label` so that it can be styled with CSS.