### PR TITLE
Fix Haddock formatting of URLs in brackets

### DIFF
--- a/src/System/Taffybar/Widget/FreedesktopNotifications.hs
+++ b/src/System/Taffybar/Widget/FreedesktopNotifications.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | This widget listens on DBus for freedesktop notifications
--- (http://developer.gnome.org/notification-spec/).  Currently it is
+-- (<http://developer.gnome.org/notification-spec/>).  Currently it is
 -- somewhat ugly, but the format is somewhat configurable.  A visual
 -- overhaul of the widget is coming.
 --

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -11,7 +11,7 @@
 --
 -- This is a "Now Playing" widget that listens for MPRIS2 events on DBus. You
 -- can find the MPRIS2 specification here at
--- (https://specifications.freedesktop.org/mpris-spec/latest/).
+-- (<https://specifications.freedesktop.org/mpris-spec/latest/>).
 -----------------------------------------------------------------------------
 module System.Taffybar.Widget.MPRIS2 ( mpris2New ) where
 

--- a/src/System/Taffybar/Widget/SimpleClock.hs
+++ b/src/System/Taffybar/Widget/SimpleClock.hs
@@ -62,7 +62,7 @@ toggleCalendar w c = do
 
 -- | Create the widget. I recommend passing @Nothing@ for the TimeLocale
 -- parameter. The format string can include Pango markup
--- (http://developer.gnome.org/pango/stable/PangoMarkupFormat.html).
+-- (<http://developer.gnome.org/pango/stable/PangoMarkupFormat.html>).
 textClockNew ::
   MonadIO m => Maybe L.TimeLocale -> String -> Double -> m GI.Gtk.Widget
 textClockNew userLocale format interval =


### PR DESCRIPTION
A few URLs were not being rendered correctly because they had surrounding punctuation (and so need to be placed in angle brackets).

Here is one example, before the fix:
![before](https://user-images.githubusercontent.com/46398799/54028920-9dd30000-419e-11e9-82f3-20735eec1941.png)
and after:
![after](https://user-images.githubusercontent.com/46398799/54028926-a592a480-419e-11e9-86d0-b96633c8f4b6.png)

