### PR TITLE
Bugfix/leaking update samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.2.2
+
+## Bug Fixes
+
+ * Solve space leaks on `updateSamples` and `getDeviceUpDown` (#472).
+
 # 3.2.1
 
 ## Bug Fixes

--- a/src/System/Taffybar/Information/Network.hs
+++ b/src/System/Taffybar/Information/Network.hs
@@ -55,7 +55,7 @@ getDeviceUpDown s = do
   dev <- initSafe <$> s `atMay` 0
   down <- readDef (-1) <$> s `atMay` 1
   up <- readDef (-1) <$> s `atMay` out
-  return (dev, (down, up))
+  dev `seq` down `seq` up `seq` return (dev, (down, up))
   where
     out = length s - 8
 

--- a/src/System/Taffybar/Information/Network.hs
+++ b/src/System/Taffybar/Information/Network.hs
@@ -113,7 +113,8 @@ updateSamples currentSamples = do
   let getLast sample@TxSample { sampleDevice = device } =
         maybe sample fst $ lookup device currentSamples
       getSamplePair sample@TxSample { sampleDevice = device } =
-        (device, (sample, getLast sample))
+        let lastSample = getLast sample
+        in lastSample `seq` (device, (sample, lastSample))
   maybe currentSamples (map getSamplePair) <$> getDeviceSamples
 
 getSpeed :: TxSample -> TxSample -> (Rational, Rational)


### PR DESCRIPTION
When using `taffybar`, I saw it leaking memory under heavy network loads. The graph produced was the following 
![taffybar-linux-x86_64-before](https://user-images.githubusercontent.com/1875145/60394885-ecfbc280-9af8-11e9-9a23-fe0a6f5dc7f5.png). It showed the problem was around the functions `parseDevNet` and `updateSamples`. This was also confirmed by the retainer graph profiling. 
![taffybar-linux-x86_64-before3](https://user-images.githubusercontent.com/1875145/60394916-7f9c6180-9af9-11e9-8880-7d6c6f4ab92f.png)
 Adding `seq` on certain places i could reduce the memory consumption by those closures as shown on the following retainer profile graph.
![taffybar-linux-x86_64](https://user-images.githubusercontent.com/1875145/60394941-e28df880-9af9-11e9-8579-04d52d9d6d8d.png)
and on the cost center profile.
![taffybar-linux-x86_64](https://user-images.githubusercontent.com/1875145/60402702-118b8500-9b61-11e9-8f03-ccb8f5a8130b.png)




