### PR TITLE
Update renamed PagerHints import path in its documentation

### DIFF
--- a/src/System/Taffybar/Support/PagerHints.hs
+++ b/src/System/Taffybar/Support/PagerHints.hs
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- |
--- Module      : System.Taffybar.Hooks.PagerHints
+-- Module      : System.Taffybar.Support.PagerHints
 -- Copyright   : (c) José A. Romero L.
 -- License     : BSD3-style (see LICENSE)
 --
@@ -47,7 +47,7 @@ import qualified XMonad.StackSet as W
 --
 -- You can use this module with the following in your @xmonad.hs@ file:
 --
--- > import System.Taffybar.Hooks.PagerHints (pagerHints)
+-- > import System.Taffybar.Support.PagerHints (pagerHints)
 -- >
 -- > main = xmonad $ ewmh $ pagerHints $ defaultConfig
 -- > ...


### PR DESCRIPTION
The documentation for other modules have been updated to use the renamed module path `System.Taffybar.Support.PagerHints`, but the module itself had some stale references. 

I've updated the docstrings to reflect the module's path.