### PR TITLE
CPU/Memory Text widgets now return Taffy IO

### DIFF
--- a/src/System/Taffybar/Widget/Text/CPUMonitor.hs
+++ b/src/System/Taffybar/Widget/Text/CPUMonitor.hs
@@ -2,6 +2,7 @@ module System.Taffybar.Widget.Text.CPUMonitor (textCpuMonitorNew) where
 
 import Text.Printf ( printf )
 import qualified Text.StringTemplate as ST
+import System.Taffybar.Context (TaffyIO)
 import System.Taffybar.Information.CPU
 import System.Taffybar.Widget.Generic.PollingLabel ( pollingLabelNew )
 import qualified GI.Gtk
@@ -10,11 +11,10 @@ import qualified GI.Gtk
 -- period (in seconds).
 textCpuMonitorNew :: String -- ^ Format. You can use variables: $total$, $user$, $system$
                   -> Double -- ^ Polling period (in seconds)
-                  -> IO GI.Gtk.Widget
+                  -> TaffyIO GI.Gtk.Widget
 textCpuMonitorNew fmt period = do
   label <- pollingLabelNew period callback
-  GI.Gtk.widgetShowAll label
-  return label
+  GI.Gtk.toWidget label
   where
     callback = do
       (userLoad, systemLoad, totalLoad) <- cpuLoad

--- a/src/System/Taffybar/Widget/Text/MemoryMonitor.hs
+++ b/src/System/Taffybar/Widget/Text/MemoryMonitor.hs
@@ -1,6 +1,7 @@
 module System.Taffybar.Widget.Text.MemoryMonitor (textMemoryMonitorNew) where
 
 import qualified Text.StringTemplate as ST
+import System.Taffybar.Context (TaffyIO)
 import System.Taffybar.Information.Memory
 import System.Taffybar.Widget.Generic.PollingLabel ( pollingLabelNew )
 import qualified GI.Gtk
@@ -9,11 +10,10 @@ import qualified GI.Gtk
 -- period (in seconds).
 textMemoryMonitorNew :: String -- ^ Format. You can use variables: "used", "total", "free", "buffer", "cache", "rest", "used".
                      -> Double -- ^ Polling period in seconds.
-                     -> IO GI.Gtk.Widget
+                     -> TaffyIO GI.Gtk.Widget
 textMemoryMonitorNew fmt period = do
     label <- pollingLabelNew period callback
-    GI.Gtk.widgetShowAll label
-    return label
+    GI.Gtk.toWidget label
     where
       callback = do
         info <- parseMeminfo


### PR DESCRIPTION
Had some errors trying to get the Text CPU & Memory widgets to work.

```
Couldn't match type ‘transformers-0.5.6.2:Control.Monad.Trans.Reader.ReaderT                                                                                                                                                             
                             System.Taffybar.Context.Context IO’                                                       
                     with ‘IO’                                                                                         
      Expected type: transformers-0.5.6.2:Control.Monad.Trans.Reader.ReaderT                                           
                       System.Taffybar.Context.Context                                                                                                                                                                                         
                       IO                                                                                                                                                                                                                      
                       gi-gtk-3.0.31:GI.Gtk.Objects.Widget.Widget                                                      
        Actual type: IO gi-gtk-3.0.31:GI.Gtk.Objects.Widget.Widget
```

This patch pulls changes the return type on the widgets from IO to TaffyIO