### PR TITLE
MPRIS2: Add fallback mechanism when the default icon cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
  * Solve space leaks on `updateSamples` and `getDeviceUpDown` (#472).
+ * Prevent crash when using mpris2New and librsvg is not available (#478).
 
 # 3.2.1
 


### PR DESCRIPTION
Fixes https://github.com/taffybar/taffybar/issues/478 with a nice warning and a transparent icon

Signed-off-by: Roosembert Palacios <roosembert.palacios@epfl.ch>