### PR TITLE
Stack: Switch to LTS, add necessary extra-deps

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,15 @@ extra-deps:
 - ConfigFile-1.1.4
 - broadcast-chan-0.2.0.2
 - dbus-hslogger-0.1.0.1
+- haskell-gi-base-0.22.2
+- gi-gobject-2.0.20
+- gi-pango-1.0.20
+- gi-gio-2.0.23
+- gi-atk-2.0.19
+- gi-gdkpixbuf-2.0.21
+- gi-gdk-3.0.20
+- gi-gtk-3.0.30
+- gi-gtk-hs-0.3.7.0
 - gi-cairo-connector-0.0.1
 - gi-cairo-render-0.0.1
 - gi-dbusmenu-0.4.6
@@ -16,10 +25,17 @@ extra-deps:
 - rate-limit-1.4.1
 - status-notifier-item-0.3.0.4
 - time-units-1.0.0
+- time-1.9
+- directory-1.3.6.0
+- process-1.6.8.2
+- unix-2.7.2.2
 - xml-helpers-1.0.0
 - xdg-desktop-entry-0.1.1.0
 - binary-0.10.0.0
-resolver: nightly-2019-06-19
+- bytestring-to-vector-0.3.0.0
+
+resolver: lts-13.19
+
 nix:
   packages:
     - cairo


### PR DESCRIPTION
This PR should get Taffybar compiling with `stack` again. I've switched from a nightly resolver to an LTS, and added the necessary `extra-deps`. Moving forward, we should update the LTS, and find a configuration of extra-deps that works, but at least this gets the ball rolling again.