### PR TITLE
Add SNITray-related documentation and fix formatting

### DIFF
--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -25,7 +25,7 @@ module System.Taffybar
   -- like reserving strut space so that window managers don't put windows over
   -- it).
   --
-  -- | The config file in which you specify the gtk+ widgets to render is just a
+  -- The config file in which you specify the gtk+ widgets to render is just a
   -- Haskell source file which is used to produce a custom executable with the
   -- desired set of widgets. This approach requires that taffybar be installed
   -- as a haskell library (not merely as an executable), and that the ghc
@@ -35,7 +35,7 @@ module System.Taffybar
   -- be provided to taffybar for instantiation and execution.
   --
   -- The following code snippet is a simple example of what a taffybar
-  -- configuration might look like (also see @src/System/Taffybar/Example.hs@):
+  -- configuration might look like (also see "System.Taffybar.Example"):
   --
   -- > {-# LANGUAGE OverloadedStrings #-}
   -- > import System.Taffybar

--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -93,10 +93,17 @@ module System.Taffybar
   --
   -- * System tray compatability
   --
-  -- | "System.Taffybar.Widget.SNITray" only supports the newer StatusNotifierIcon (SNI) protocol; older xembed applets will not work. AppIndicator is also a valid implementation of SNI.
+  -- | "System.Taffybar.Widget.SNITray" only supports the newer
+  -- StatusNotifierIcon (SNI) protocol; older xembed applets will not work.
+  -- AppIndicator is also a valid implementation of SNI.
   --
-  -- Additionally, this module does not handle recognising new tray applets. Instead it is necessary to run status-notifier-watcher from the [status-notifier-icon](https://github.com/taffybar/status-notifier-icon) package early on system startup.
-  -- In case this is not possible, the alternative widget sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt is available, but this may not necessarily be able to pick up everything.
+  -- Additionally, this module does not handle recognising new tray applets.
+  -- Instead it is necessary to run status-notifier-watcher from the
+  -- [status-notifier-icon](https://github.com/taffybar/status-notifier-icon)
+  -- package early on system startup.
+  -- In case this is not possible, the alternative widget
+  -- sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt is available, but
+  -- this may not necessarily be able to pick up everything.
 
   -- * Colors
   --

--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -94,12 +94,12 @@ module System.Taffybar
   -- * System tray compatability
   --
   -- | "System.Taffybar.Widget.SNITray" only supports the newer
-  -- StatusNotifierIcon (SNI) protocol; older xembed applets will not work.
+  -- StatusNotifierItem (SNI) protocol; older xembed applets will not work.
   -- AppIndicator is also a valid implementation of SNI.
   --
   -- Additionally, this module does not handle recognising new tray applets.
   -- Instead it is necessary to run status-notifier-watcher from the
-  -- [status-notifier-icon](https://github.com/taffybar/status-notifier-icon)
+  -- [status-notifier-item](https://github.com/taffybar/status-notifier-item)
   -- package early on system startup.
   -- In case this is not possible, the alternative widget
   -- sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt is available, but

--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -90,6 +90,13 @@ module System.Taffybar
   --
   -- * If you start xmonad via @startx@ or a similar command, add the
   -- above command to ~\/.xinitrc
+  --
+  -- * System tray compatability
+  --
+  -- | "System.Taffybar.Widget.SNITray" only supports the newer StatusNotifierIcon (SNI) protocol; older xembed applets will not work. AppIndicator is also a valid implementation of SNI.
+  --
+  -- Additionally, this module does not handle recognising new tray applets. Instead it is necessary to run status-notifier-watcher from the [status-notifier-icon](https://github.com/taffybar/status-notifier-icon) package early on system startup.
+  -- In case this is not possible, the alternative widget sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt is available, but this may not necessarily be able to pick up everything.
 
   -- * Colors
   --

--- a/src/System/Taffybar/Widget/SNITray.hs
+++ b/src/System/Taffybar/Widget/SNITray.hs
@@ -9,6 +9,21 @@
 -- Stability   : unstable
 -- Portability : unportable
 -----------------------------------------------------------------------------
+
+-- | A widget to display the system tray.
+--
+-- This widget only supports the newer StatusNotifierItem (SNI) protocol;
+-- older xembed applets will not be visible. AppIndicator is also a valid
+-- implementation of SNI.
+--
+-- Additionally, it does not handle recognising new tray applets. Instead it is
+-- necessary to run status-notifier-watcher from the
+-- [status-notifier-item](https://github.com/taffybar/status-notifier-item)
+-- package early on system startup.
+-- In case this is not possiblle,
+-- 'sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt is available, but
+-- this may not necessarily be able to pick up everything.
+
 module System.Taffybar.Widget.SNITray where
 
 import           Control.Monad.Trans.Class
@@ -55,9 +70,13 @@ sniTrayNewFromHost host = do
     GI.Gtk.widgetShowAll tray
     GI.Gtk.toWidget tray
 
+-- | The simplest way to build a new StatusNotifierItem tray
 sniTrayNew :: TaffyIO GI.Gtk.Widget
 sniTrayNew = getHost False >>= sniTrayNewFromHost
 
+-- | Build a new StatusNotifierItem tray that also starts its own watcher,
+-- without depending on status-notifier-icon. This will not register applets
+-- started before the watcher is started.
 sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt :: TaffyIO GI.Gtk.Widget
 sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt =
   getHost True >>= sniTrayNewFromHost

--- a/src/System/Taffybar/Widget/SNITray.hs
+++ b/src/System/Taffybar/Widget/SNITray.hs
@@ -9,8 +9,8 @@
 -- Stability   : unstable
 -- Portability : unportable
 -----------------------------------------------------------------------------
-
--- | A widget to display the system tray.
+--
+-- A widget to display the system tray.
 --
 -- This widget only supports the newer StatusNotifierItem (SNI) protocol;
 -- older xembed applets will not be visible. AppIndicator is also a valid


### PR DESCRIPTION
Add haddock documentation to System.Taffybar and System.TaffyBar.Widget.SNITray to clarify some things I struggled with recently in setting up taffybar. Namely, that only the SNI protocol is supported, and that status-notifier-watcher needs to be run.

Additionally, I fixed a couple of errors in the formatting of System.Taffybar that were stopping the Haddock documentation from displaying correctly.