### PR TITLE
Compatibility fix for haskell-gi-base 0.24

### DIFF
--- a/src/System/Taffybar/Widget/Util.hs
+++ b/src/System/Taffybar/Widget/Util.hs
@@ -66,7 +66,7 @@ attachPopup widget title window = do
   where
     getWindow :: IO (Maybe Window)
     getWindow = do
-          windowGType <- gobjectType @Window
+          windowGType <- glibType @Window
           Just ancestor <- Gtk.widgetGetAncestor widget windowGType
           castTo Window ancestor
 


### PR DESCRIPTION
Trying to compile against haskell-gi-base version 0.24 yields the following error:

```
[27 of 64] Compiling System.Taffybar.Widget.Util ( src/System/Taffybar/Widget/Util.hs, dist/build/System/Taffybar/Widget/Util.o )

src/System/Taffybar/Widget/Util.hs:69:26: error:
    Variable not in scope: gobjectType
   |
69 |           windowGType <- gobjectType @Window
   |                          ^^^^^^^^^^^

src/System/Taffybar/Widget/Util.hs:69:26: error:
    • Cannot apply expression of type ‘t1’
      to a visible type argument ‘Window’
    • In a stmt of a 'do' block: windowGType <- gobjectType @Window
      In the expression:
        do windowGType <- gobjectType @Window
           Just ancestor <- widgetGetAncestor widget windowGType
           castTo Window ancestor
      In an equation for ‘getWindow’:
          getWindow
            = do windowGType <- gobjectType @Window
                 Just ancestor <- widgetGetAncestor widget windowGType
                 castTo Window ancestor
   |
69 |           windowGType <- gobjectType @Window
   |                          ^^^^^^^^^^^^^^^^^^^
[58 of 64] Compiling System.Taffybar.Widget.XDGMenu.Menu ( src/System/Taffybar/Widget/XDGMenu/Menu.hs, dist/build/System/Taffybar/Widget/XDGMenu/Menu.o )
builder for '/nix/store/4cgwp0v2jycdw9nfcrfz4dafm1zys9a8-taffybar-3.2.2.drv' failed with exit code 1
error: build of '/nix/store/4cgwp0v2jycdw9nfcrfz4dafm1zys9a8-taffybar-3.2.2.drv' failed
```

Looking at https://hackage.haskell.org/package/haskell-gi-base-0.23.0/docs/Data-GI-Base-BasicTypes.html and https://hackage.haskell.org/package/haskell-gi-base-0.24.2/docs/Data-GI-Base-BasicTypes.html, it seems like `gobjectType` was renamed `glibType`.