### PR TITLE
Add named icons to System.Taffybar.Widget.Generic.Icon

### DIFF
--- a/src/System/Taffybar/Widget/Generic/Icon.hs
+++ b/src/System/Taffybar/Widget/Generic/Icon.hs
@@ -2,7 +2,9 @@
 -- updates its contents by calling a callback at a set interval.
 module System.Taffybar.Widget.Generic.Icon
   ( iconImageWidgetNew
+  , iconImageWidgetNewFromName
   , pollingIconImageWidgetNew
+  , pollingIconImageWidgetNewFromName
   ) where
 
 import Control.Concurrent ( forkIO, threadDelay )

--- a/src/System/Taffybar/Widget/Generic/Icon.hs
+++ b/src/System/Taffybar/Widget/Generic/Icon.hs
@@ -6,6 +6,7 @@ module System.Taffybar.Widget.Generic.Icon
   ) where
 
 import Control.Concurrent ( forkIO, threadDelay )
+import qualified Data.Text as T
 import Control.Exception as E
 import Control.Monad ( forever )
 import Control.Monad.IO.Class
@@ -19,6 +20,16 @@ import System.Taffybar.Util
 -- returns a widget with icon at @path@.
 iconImageWidgetNew :: MonadIO m => FilePath -> m Widget
 iconImageWidgetNew path = liftIO $ imageNewFromFile path >>= putInBox
+
+-- | Create a new widget that displays a static image
+--
+-- > iconWidgetNewFromName name
+--
+-- returns a widget with the icon named @name@. Icon
+-- names are sourced from the current GTK theme. 
+iconImageWidgetNewFromName :: MonadIO m => T.Text -> m Widget
+iconImageWidgetNewFromName name = liftIO $ 
+  imageNewFromIconName (Just name) (fromIntegral $ fromEnum IconSizeMenu) >>= putInBox
 
 -- | Create a new widget that updates itself at regular intervals.  The
 -- function


### PR DESCRIPTION
This PR adds named icons to the generic icon widget that ships with taffybar. This would allow for much easier creation of widgets involving icons, as users could just use icons from their GTK theme, and avoid having to homebrew their own versions of this widget to do so. 

Adds 2 new functions - `iconImageWidgetNewFromName` and `pollingIconImageWidgetNewFromName`. 

As an example, `iconImageWidgetNewFromName "weather-clouds"` yields an icon that looks like ![image](https://user-images.githubusercontent.com/35076430/91073673-64e45080-e609-11ea-8965-f107a304a21f.png). `pollingIconImageWidgetNewFromName` works similarly to `pollingIconImageWidgetNew`, but as with `iconImageWidgetNewFromName`, you get the added benefit of specifying via icon names as opposed to paths. 

Most of the source here was taken from [my personal modifications](https://gitlab.com/myriacore-dotfiles/taffybar/-/blob/ad1c1919ac840a295b190179f7e334e544b22f37/Widget/Generic/Icon.hs) of `System.Taffybar.Widget.Generic.Icon`.
