### PR TITLE
memoryAvailable action inside Text MemoryMonitor widget

### DIFF
--- a/src/System/Taffybar/Widget/Text/MemoryMonitor.hs
+++ b/src/System/Taffybar/Widget/Text/MemoryMonitor.hs
@@ -9,7 +9,7 @@ import qualified GI.Gtk
 -- | Creates a simple textual memory monitor. It updates once every polling
 -- period (in seconds).
 textMemoryMonitorNew :: MonadIO m
-                     => String -- ^ Format. You can use variables: "used", "total", "free", "buffer", "cache", "rest", "used".
+                     => String -- ^ Format. You can use variables: "used", "total", "free", "buffer", "cache", "rest", "available".
                      -> Double -- ^ Polling period in seconds.
                      -> m GI.Gtk.Widget
 textMemoryMonitorNew fmt period = do
@@ -19,8 +19,8 @@ textMemoryMonitorNew fmt period = do
       callback = do
         info <- parseMeminfo
         let template = ST.newSTMP fmt
-        let labels = ["used", "total", "free", "buffer", "cache", "rest", "used"]
-        let actions = [memoryUsed, memoryTotal, memoryFree, memoryBuffer, memoryCache, memoryRest]
+        let labels = ["used", "total", "free", "buffer", "cache", "rest", "available"]
+        let actions = [memoryUsed, memoryTotal, memoryFree, memoryBuffer, memoryCache, memoryRest, memoryAvailable]
             actions' = map ((show . intRound).) actions
         let stats = [f info | f <- actions']
         let template' = ST.setManyAttrib (zip labels stats) template


### PR DESCRIPTION
Make memoryAvailable action available inside the Text MemoryMonitor widget.

Looks like "used" was accidentally added twice instead of "available".