### PR TITLE
gi-gdkpixbuf-2.0.26 fix

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -2,7 +2,7 @@ self: super:
 
 let
   sourceTransformer = if builtins.getEnv "CI" == "" then builtins.fetchGit else (x: x);
-  taffybarOverlay = _: pkgs: {
+  taffybarOverlay = _: pkgs: with pkgs.haskell.lib; {
     haskellPackages = pkgs.haskellPackages.override (old: {
       overrides =
         pkgs.lib.composeExtensions (old.overrides or (_: _: {}))
@@ -10,6 +10,11 @@ let
           taffybar =
             self.callCabal2nix "taffybar" (sourceTransformer ./.)
             { inherit (pkgs) gtk3; };
+          # https://github.com/taffybar/gtk-sni-tray/pull/25
+          gtk-sni-tray = markUnbroken (appendPatch super.gtk-sni-tray (pkgs.fetchpatch {
+            url = "https://github.com/rvl/gtk-sni-tray/commit/4afd84654cb3f2bd2bb7d39451706c5914fd3cdf.patch";
+            sha256 = "1xjxlh58vnykqsjq4qw8mliq3gk17mwxi4h9z8dvjyav8zqg05rn";
+          }));
         });
     });
   };

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -59,7 +59,7 @@ mpris2New = asks sessionDBusClient >>= \client -> lift $ do
     newPlayerWidget :: BusName -> IO MPRIS2PlayerWidget
     newPlayerWidget busName =
       do
-        let loadDefault size = catchGErrorsAsLeft (loadIcon size "play.svg")
+        let loadDefault size = loadIcon size "play.svg"
                 >>= either failure return
               where failure err =
                       mprisLog WARNING "Failed to load default image: %s" err >>


### PR DESCRIPTION
Makes it buildable with gi-gdkpixbuf 2.0.26 and prior versions.

See also: https://github.com/taffybar/gtk-sni-tray/pull/25