### PR TITLE
Make MPRIS widget more tolerant of missing xesam:artist

### DIFF
--- a/src/System/Taffybar/Information/MPRIS2.hs
+++ b/src/System/Taffybar/Information/MPRIS2.hs
@@ -14,6 +14,7 @@
 
 module System.Taffybar.Information.MPRIS2 where
 
+import           Control.Applicative
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Except
@@ -68,6 +69,6 @@ getNowPlayingInfo client =
 getSongInfo :: M.Map String DBus.Variant -> Maybe (String, [String])
 getSongInfo songData = do
   let lookupVariant k = M.lookup k songData >>= DBus.fromVariant
-  artists <- lookupVariant "xesam:artist"
+  artists <- lookupVariant "xesam:artist" <|> pure []
   title <- lookupVariant "xesam:title"
   return (title, artists)

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -260,7 +260,10 @@ mpris2NewWithConfig config = ask >>= \ctx -> asks sessionDBusClient >>= \client 
 playingText :: MonadIO m => Int -> Int -> NowPlaying -> m T.Text
 playingText artistMax songMax NowPlaying {npArtists = artists, npTitle = title} =
   G.markupEscapeText formattedText (-1)
-  where formattedText = T.pack $ printf
+  where truncatedTitle = truncateString songMax title
+        formattedText = T.pack $ if null artists
+          then truncatedTitle
+          else printf
            "%s - %s"
            (truncateString artistMax $ intercalate "," artists)
-           (truncateString songMax title)
+           truncatedTitle


### PR DESCRIPTION
This makes `getSongInfo` not fail when there is missing `xesam:artist` metadata exposed. In particular, I noticed that when using https://github.com/hoyon/mpv-mpris to play YouTube videos, this metadata is missing. This means that the widget does not draw. I also changed the view function to prevent it from displaying ` - %{title}` in the absence of artists.