### PR TITLE
Use Data.Default for Default Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
    tooltips.
 
  * Swap variables are added to `MemoryMonitor`.
+ 
+ * Many types have `Default` instances.
 
 ## Changes
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,6 +3,7 @@
 -- recompile itself.
 module Main ( main ) where
 
+import Data.Default (def)
 import Data.Semigroup ((<>))
 import Data.Version
 import Options.Applicative
@@ -47,7 +48,7 @@ main = do
 
   if configurationExists
   -- XXX: The configuration record here does not get used, this just calls in to dyre.
-  then dyreTaffybar defaultTaffybarConfig
+  then dyreTaffybar def
   else do
     logM "System.Taffybar" WARNING $
            (  printf "No taffybar configuration file found at %s." taffyFilepath

--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -39,6 +39,7 @@ module System.Taffybar
   -- configuration might look like (also see "System.Taffybar.Example"):
   --
   -- > {-# LANGUAGE OverloadedStrings #-}
+  -- > import Data.Default (def)
   -- > import System.Taffybar
   -- > import System.Taffybar.Information.CPU
   -- > import System.Taffybar.SimpleConfig
@@ -51,14 +52,14 @@ module System.Taffybar
   -- >   return [ totalLoad, systemLoad ]
   -- >
   -- > main = do
-  -- >   let cpuCfg = defaultGraphConfig
+  -- >   let cpuCfg = def
   -- >                  { graphDataColors = [ (0, 1, 0, 1), (1, 0, 1, 0.5)]
   -- >                  , graphLabel = Just "cpu"
   -- >                  }
-  -- >       clock = textClockNewWith defaultClockConfig
+  -- >       clock = textClockNewWith def
   -- >       cpu = pollingGraphNew cpuCfg 0.5 cpuCallback
-  -- >       workspaces = workspacesNew defaultWorkspacesConfig
-  -- >       simpleConfig = defaultSimpleTaffyConfig
+  -- >       workspaces = workspacesNew def
+  -- >       simpleConfig = def
   -- >                        { startWidgets = [ workspaces ]
   -- >                        , endWidgets = [ sniTrayNew, clock, cpu ]
   -- >                        }

--- a/src/System/Taffybar/Context.hs
+++ b/src/System/Taffybar/Context.hs
@@ -57,6 +57,7 @@ import           Control.Monad.Trans.Maybe
 import           Control.Monad.Trans.Reader
 import qualified DBus.Client as DBus
 import           Data.Data
+import           Data.Default (Default(def))
 import           Data.GI.Base.ManagedPtr (unsafeCastTo)
 import           Data.Int
 import           Data.List
@@ -163,6 +164,9 @@ defaultTaffybarConfig = TaffybarConfig
   , errorMsg = Nothing
   }
 
+instance Default TaffybarConfig where
+  def = defaultTaffybarConfig
+
 -- | A "Context" value holds all of the state associated with a single running
 -- instance of taffybar. It is typically accessed from a widget constructor
 -- through the "TaffyIO" monad transformer stack.
@@ -241,7 +245,7 @@ buildContext TaffybarConfig
 -- invoking functions that yield 'TaffyIO' values in a testing setting (e.g. in
 -- a repl).
 buildEmptyContext :: IO Context
-buildEmptyContext = buildContext defaultTaffybarConfig
+buildEmptyContext = buildContext def
 
 buildBarWindow :: Context -> BarConfig -> IO Gtk.Window
 buildBarWindow context barConfig = do

--- a/src/System/Taffybar/Context.hs
+++ b/src/System/Taffybar/Context.hs
@@ -57,7 +57,7 @@ import           Control.Monad.Trans.Maybe
 import           Control.Monad.Trans.Reader
 import qualified DBus.Client as DBus
 import           Data.Data
-import           Data.Default (Default(def))
+import           Data.Default (Default(..))
 import           Data.GI.Base.ManagedPtr (unsafeCastTo)
 import           Data.Int
 import           Data.List

--- a/src/System/Taffybar/Context.hs
+++ b/src/System/Taffybar/Context.hs
@@ -378,11 +378,11 @@ runX11 action =
 -- property. Return the provided default if 'Nothing' is returned
 -- 'postX11RequestSyncProp'.
 runX11Def :: a -> X11Property a -> TaffyIO a
-runX11Def def prop = runX11 $ postX11RequestSyncProp prop def
+runX11Def dflt prop = runX11 $ postX11RequestSyncProp prop dflt
 
 runX11Context :: MonadIO m => Context -> a -> X11Property a -> m a
-runX11Context context def prop =
-  liftIO $ runReaderT (runX11Def def prop) context
+runX11Context context dflt prop =
+  liftIO $ runReaderT (runX11Def dflt prop) context
 
 -- | Get a state value by type from the 'contextState' field of 'Context'.
 getState :: forall t. Typeable t => Taffy IO (Maybe t)

--- a/src/System/Taffybar/Example.hs
+++ b/src/System/Taffybar/Example.hs
@@ -17,6 +17,7 @@ module System.Taffybar.Example where
 --
 -- > main = dyreTaffybar exampleTaffybarConfig
 
+import Data.Default (def)
 import System.Taffybar.Context (TaffybarConfig(..))
 import System.Taffybar.Hooks
 import System.Taffybar.Information.CPU
@@ -36,7 +37,7 @@ taffyBlue = (0.129, 0.588, 0.953, 1)
 
 myGraphConfig, netCfg, memCfg, cpuCfg :: GraphConfig
 myGraphConfig =
-  defaultGraphConfig
+  def
   { graphPadding = 0
   , graphBorderWidth = 0
   , graphWidth = 75
@@ -71,7 +72,7 @@ cpuCallback = do
 exampleTaffybarConfig :: TaffybarConfig
 exampleTaffybarConfig =
   let myWorkspacesConfig =
-        defaultWorkspacesConfig
+        def
         { minIcons = 1
         , widgetGap = 0
         , showWorkspaceFn = hideEmpty
@@ -80,13 +81,13 @@ exampleTaffybarConfig =
       cpu = pollingGraphNew cpuCfg 0.5 cpuCallback
       mem = pollingGraphNew memCfg 1 memCallback
       net = networkGraphNew netCfg Nothing
-      clock = textClockNewWith defaultClockConfig
-      layout = layoutNew defaultLayoutConfig
-      windowsW = windowsNew defaultWindowsConfig
+      clock = textClockNewWith def
+      layout = layoutNew def
+      windowsW = windowsNew def
       -- See https://github.com/taffybar/gtk-sni-tray#statusnotifierwatcher
       -- for a better way to set up the sni tray
       tray = sniTrayThatStartsWatcherEvenThoughThisIsABadWayToDoIt
-      myConfig = defaultSimpleTaffyConfig
+      myConfig = def
         { startWidgets =
             workspaces : map (>>= buildContentsBox) [ layout, windowsW ]
         , endWidgets = map (>>= buildContentsBox)

--- a/src/System/Taffybar/SimpleConfig.hs
+++ b/src/System/Taffybar/SimpleConfig.hs
@@ -25,6 +25,7 @@ module System.Taffybar.SimpleConfig
 import qualified Control.Concurrent.MVar as MV
 import           Control.Monad
 import           Control.Monad.Trans.Class
+import           Data.Default (Default(def))
 import           Data.List
 import           Data.Maybe
 import           Data.Unique
@@ -84,6 +85,9 @@ defaultSimpleTaffyConfig = SimpleTaffyConfig
   , cssPaths = []
   , startupHook = return ()
   }
+
+instance Default SimpleTaffyConfig where
+  def = defaultSimpleTaffyConfig
 
 -- | Convert a 'SimpleTaffyConfig' into a 'StrutConfig' that can be used with
 -- gtk-strut.

--- a/src/System/Taffybar/SimpleConfig.hs
+++ b/src/System/Taffybar/SimpleConfig.hs
@@ -128,7 +128,7 @@ newtype SimpleBarConfigs = SimpleBarConfigs (MV.MVar [(Int, BC.BarConfig)])
 -- with 'startTaffybar' or 'dyreTaffybar'.
 toTaffyConfig :: SimpleTaffyConfig -> BC.TaffybarConfig
 toTaffyConfig conf =
-    defaultTaffybarConfig
+    def
     { BC.getBarConfigsParam = configGetter
     , BC.cssPaths = cssPaths conf
     , BC.startupHook = startupHook conf

--- a/src/System/Taffybar/SimpleConfig.hs
+++ b/src/System/Taffybar/SimpleConfig.hs
@@ -25,7 +25,7 @@ module System.Taffybar.SimpleConfig
 import qualified Control.Concurrent.MVar as MV
 import           Control.Monad
 import           Control.Monad.Trans.Class
-import           Data.Default (Default(def))
+import           Data.Default (Default(..))
 import           Data.List
 import           Data.Maybe
 import           Data.Unique

--- a/src/System/Taffybar/Widget/Battery.hs
+++ b/src/System/Taffybar/Widget/Battery.hs
@@ -26,6 +26,7 @@ import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Reader
+import           Data.Default (Default(def))
 import           Data.Int (Int64)
 import qualified Data.Text as T
 import           GI.Gtk as Gtk
@@ -91,7 +92,7 @@ formatBattInfo info fmt =
 textBatteryNew :: String -> TaffyIO Widget
 textBatteryNew format = textBatteryNewWithLabelAction labelSetter
   where labelSetter label info = do
-          setBatteryStateClasses defaultBatteryClassesConfig label info
+          setBatteryStateClasses def label info
           labelSetMarkup label $
                          formatBattInfo (getBatteryWidgetInfo info) format
 
@@ -108,6 +109,9 @@ defaultBatteryClassesConfig =
   , batteryLowThreshold = 20
   , batteryCriticalThreshold = 5
   }
+
+instance Default BatteryClassesConfig where
+  def = defaultBatteryClassesConfig
 
 setBatteryStateClasses ::
   MonadIO m => BatteryClassesConfig -> Gtk.Label -> BatteryInfo -> m ()

--- a/src/System/Taffybar/Widget/Battery.hs
+++ b/src/System/Taffybar/Widget/Battery.hs
@@ -26,7 +26,7 @@ import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Reader
-import           Data.Default (Default(def))
+import           Data.Default (Default(..))
 import           Data.Int (Int64)
 import qualified Data.Text as T
 import           GI.Gtk as Gtk

--- a/src/System/Taffybar/Widget/FreedesktopNotifications.hs
+++ b/src/System/Taffybar/Widget/FreedesktopNotifications.hs
@@ -34,7 +34,7 @@ import           Control.Monad ( forever, void )
 import           Control.Monad.IO.Class
 import           DBus
 import           DBus.Client
-import           Data.Default ( Default(def) )
+import           Data.Default ( Default(..) )
 import           Data.Foldable
 import           Data.Int ( Int32 )
 import           Data.Map ( Map )

--- a/src/System/Taffybar/Widget/FreedesktopNotifications.hs
+++ b/src/System/Taffybar/Widget/FreedesktopNotifications.hs
@@ -34,6 +34,7 @@ import           Control.Monad ( forever, void )
 import           Control.Monad.IO.Class
 import           DBus
 import           DBus.Client
+import           Data.Default ( Default(def) )
 import           Data.Foldable
 import           Data.Int ( Int32 )
 import           Data.Map ( Map )
@@ -233,6 +234,9 @@ defaultNotificationConfig =
                      , notificationMaxLength = 100
                      , notificationFormatter = defaultFormatter
                      }
+
+instance Default NotificationConfig where
+  def = defaultNotificationConfig
 
 -- | Create a new notification area with the given configuration.
 notifyAreaNew :: MonadIO m => NotificationConfig -> m Widget

--- a/src/System/Taffybar/Widget/Generic/Graph.hs
+++ b/src/System/Taffybar/Widget/Generic/Graph.hs
@@ -23,7 +23,7 @@ module System.Taffybar.Widget.Generic.Graph (
 import           Control.Concurrent
 import           Control.Monad ( when )
 import           Control.Monad.IO.Class
-import           Data.Default ( Default(def) )
+import           Data.Default ( Default(..) )
 import           Data.Foldable ( mapM_ )
 import           Data.Sequence ( Seq, (<|), viewl, ViewL(..) )
 import qualified Data.Sequence as S

--- a/src/System/Taffybar/Widget/Generic/Graph.hs
+++ b/src/System/Taffybar/Widget/Generic/Graph.hs
@@ -23,6 +23,7 @@ module System.Taffybar.Widget.Generic.Graph (
 import           Control.Concurrent
 import           Control.Monad ( when )
 import           Control.Monad.IO.Class
+import           Data.Default ( Default(def) )
 import           Data.Foldable ( mapM_ )
 import           Data.Sequence ( Seq, (<|), viewl, ViewL(..) )
 import qualified Data.Sequence as S
@@ -93,6 +94,9 @@ defaultGraphConfig =
   , graphWidth = 50
   , graphDirection = LEFT_TO_RIGHT
   }
+
+instance Default GraphConfig where
+  def = defaultGraphConfig
 
 -- | Add a data point to the graph for each of the tracked data sets. There
 -- should be as many values in the list as there are data sets.

--- a/src/System/Taffybar/Widget/Layout.hs
+++ b/src/System/Taffybar/Widget/Layout.hs
@@ -26,6 +26,7 @@ module System.Taffybar.Widget.Layout
 
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Reader
+import           Data.Default (Default(def))
 import qualified Data.Text as T
 import qualified GI.Gtk as Gtk
 import           GI.Gdk
@@ -49,7 +50,7 @@ import           System.Taffybar.Widget.Util
 --
 -- > import System.Taffybar.Widget.Layout
 -- > main = do
--- >   let los = layoutSwitcherNew defaultLayoutConfig
+-- >   let los = layoutSwitcherNew def
 --
 -- now you can use @los@ as any other Taffybar widget.
 
@@ -59,6 +60,9 @@ newtype LayoutConfig = LayoutConfig
 
 defaultLayoutConfig :: LayoutConfig
 defaultLayoutConfig = LayoutConfig return
+
+instance Default LayoutConfig where
+  def = defaultLayoutConfig
 
 -- | Name of the X11 events to subscribe, and of the hint to look for for
 -- the name of the current layout.

--- a/src/System/Taffybar/Widget/Layout.hs
+++ b/src/System/Taffybar/Widget/Layout.hs
@@ -26,7 +26,7 @@ module System.Taffybar.Widget.Layout
 
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Reader
-import           Data.Default (Default(def))
+import           Data.Default (Default(..))
 import qualified Data.Text as T
 import qualified GI.Gtk as Gtk
 import           GI.Gdk

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -28,6 +28,7 @@ import           Control.Monad.Trans.Reader
 import           DBus
 import           DBus.Client
 import qualified DBus.TH as DBus
+import           Data.Default (Default(def))
 import           Data.GI.Base.Overloading (IsDescendantOf)
 import           Data.List
 import qualified Data.Map as M
@@ -83,7 +84,7 @@ defaultMPRIS2Config :: MPRIS2Config MPRIS2PlayerWidget
 defaultMPRIS2Config =
   MPRIS2Config
   { mprisWidgetWrapper = return
-  , updatePlayerWidget = simplePlayerWidget defaultPlayerConfig
+  , updatePlayerWidget = simplePlayerWidget def
   }
 
 data MPRIS2PlayerWidget = MPRIS2PlayerWidget
@@ -102,6 +103,9 @@ defaultPlayerConfig = SimpleMPRIS2PlayerConfig
   , showPlayerWidgetFn =
     \NowPlaying { npStatus = status } -> return $ status /= "Stopped"
   }
+
+instance Default SimpleMPRIS2PlayerConfig where
+  def = defaultPlayerConfig
 
 makeExcept :: String -> (a -> IO (Maybe b)) -> a -> ExceptT String IO b
 makeExcept errorString actionBuilder =

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -28,7 +28,7 @@ import           Control.Monad.Trans.Reader
 import           DBus
 import           DBus.Client
 import qualified DBus.TH as DBus
-import           Data.Default (Default(def))
+import           Data.Default (Default(..))
 import           Data.GI.Base.Overloading (IsDescendantOf)
 import           Data.List
 import qualified Data.Map as M

--- a/src/System/Taffybar/Widget/NetworkGraph.hs
+++ b/src/System/Taffybar/Widget/NetworkGraph.hs
@@ -13,6 +13,7 @@
 
 module System.Taffybar.Widget.NetworkGraph where
 
+import Data.Default (Default(def))
 import Data.Foldable (for_)
 import qualified GI.Gtk
 import GI.Gtk.Objects.Widget (widgetSetTooltipMarkup)
@@ -48,11 +49,14 @@ defaultNetworkGraphConfig = NetworkGraphConfig
   , interfacesFilter = const True
   }
 
+instance Default NetworkGraphConfig where
+  def = defaultNetworkGraphConfig
+
 -- | 'networkGraphNew' instantiates a network graph widget from a 'GraphConfig'
 -- and a list of interfaces.
 networkGraphNew :: GraphConfig -> Maybe [String] -> TaffyIO GI.Gtk.Widget
 networkGraphNew config interfaces =
-  networkGraphNewWith defaultNetworkGraphConfig
+  networkGraphNewWith def
                         { networkGraphGraphConfig = config
                         , interfacesFilter = maybe (const True) (flip elem) interfaces
                         }

--- a/src/System/Taffybar/Widget/NetworkGraph.hs
+++ b/src/System/Taffybar/Widget/NetworkGraph.hs
@@ -43,7 +43,7 @@ data NetworkGraphConfig = NetworkGraphConfig
 -- | Default configuration paramters for the network graph.
 defaultNetworkGraphConfig :: NetworkGraphConfig
 defaultNetworkGraphConfig = NetworkGraphConfig
-  { networkGraphGraphConfig = defaultGraphConfig
+  { networkGraphGraphConfig = def
   , networkGraphTooltipFormat = Just (defaultNetFormat, 3)
   , networkGraphScale = logBase $ 2 ** 32
   , interfacesFilter = const True

--- a/src/System/Taffybar/Widget/NetworkGraph.hs
+++ b/src/System/Taffybar/Widget/NetworkGraph.hs
@@ -13,7 +13,7 @@
 
 module System.Taffybar.Widget.NetworkGraph where
 
-import Data.Default (Default(def))
+import Data.Default (Default(..))
 import Data.Foldable (for_)
 import qualified GI.Gtk
 import GI.Gtk.Objects.Widget (widgetSetTooltipMarkup)

--- a/src/System/Taffybar/Widget/SimpleClock.hs
+++ b/src/System/Taffybar/Widget/SimpleClock.hs
@@ -10,6 +10,7 @@ module System.Taffybar.Widget.SimpleClock
   ) where
 
 import           Control.Monad.IO.Class
+import           Data.Default ( Default(def) )
 import           Data.Maybe
 import qualified Data.Text as T
 import           Data.Time.Calendar ( toGregorian )
@@ -62,10 +63,10 @@ textClockNew ::
 textClockNew userLocale format interval =
   textClockNewWith cfg
   where
-    cfg = defaultClockConfig { clockTimeLocale = userLocale
-                             , clockFormatString = format
-                             , clockUpdateStrategy = ConstantInterval interval
-                             }
+    cfg = def { clockTimeLocale = userLocale
+              , clockFormatString = format
+              , clockUpdateStrategy = ConstantInterval interval
+              }
 
 data ClockUpdateStrategy
   = ConstantInterval Double
@@ -87,6 +88,9 @@ defaultClockConfig = ClockConfig
   , clockFormatString = "%a %b %_d %r"
   , clockUpdateStrategy = RoundedTargetInterval 5 0.0
   }
+
+instance Default ClockConfig where
+  def = defaultClockConfig
 
 systemGetTZ :: IO TimeZone
 systemGetTZ = setTZ >> getCurrentTimeZone

--- a/src/System/Taffybar/Widget/SimpleClock.hs
+++ b/src/System/Taffybar/Widget/SimpleClock.hs
@@ -10,7 +10,7 @@ module System.Taffybar.Widget.SimpleClock
   ) where
 
 import           Control.Monad.IO.Class
-import           Data.Default ( Default(def) )
+import           Data.Default ( Default(..) )
 import           Data.Maybe
 import qualified Data.Text as T
 import           Data.Time.Calendar ( toGregorian )

--- a/src/System/Taffybar/Widget/Windows.hs
+++ b/src/System/Taffybar/Widget/Windows.hs
@@ -19,6 +19,7 @@ module System.Taffybar.Widget.Windows where
 import           Control.Monad
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Reader
+import           Data.Default (Default(def))
 import           Data.Maybe
 import qualified Data.Text as T
 import           GI.GLib (markupEscapeText)
@@ -62,6 +63,9 @@ defaultWindowsConfig =
   { getMenuLabel = truncatedGetMenuLabel 35
   , getActiveLabel = truncatedGetActiveLabel 35
   }
+
+instance Default WindowsConfig where
+  def = defaultWindowsConfig
 
 -- | Create a new Windows widget that will use the given Pager as
 -- its source of events.

--- a/src/System/Taffybar/Widget/Windows.hs
+++ b/src/System/Taffybar/Widget/Windows.hs
@@ -19,7 +19,7 @@ module System.Taffybar.Widget.Windows where
 import           Control.Monad
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Reader
-import           Data.Default (Default(def))
+import           Data.Default (Default(..))
 import           Data.Maybe
 import qualified Data.Text as T
 import           GI.GLib (markupEscapeText)

--- a/src/System/Taffybar/Widget/Workspaces.hs
+++ b/src/System/Taffybar/Widget/Workspaces.hs
@@ -24,6 +24,7 @@ import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
 import           Control.Monad.Trans.Reader
 import           Control.RateLimit
+import           Data.Default (Default(def))
 import qualified Data.Foldable as F
 import           Data.GI.Base.ManagedPtr (unsafeCastTo)
 import           Data.Int
@@ -178,6 +179,9 @@ defaultWorkspacesConfig =
   , updateRateLimitMicroseconds = 100000
   , urgentWorkspaceState = False
   }
+
+instance Default WorkspacesConfig where
+  def = defaultWorkspacesConfig
 
 hideEmpty :: Workspace -> Bool
 hideEmpty Workspace { workspaceState = Empty } = False

--- a/src/System/Taffybar/Widget/Workspaces.hs
+++ b/src/System/Taffybar/Widget/Workspaces.hs
@@ -24,7 +24,7 @@ import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
 import           Control.Monad.Trans.Reader
 import           Control.RateLimit
-import           Data.Default (Default(def))
+import           Data.Default (Default(..))
 import qualified Data.Foldable as F
 import           Data.GI.Base.ManagedPtr (unsafeCastTo)
 import           Data.Int

--- a/src/System/Taffybar/Widget/Workspaces.hs
+++ b/src/System/Taffybar/Widget/Workspaces.hs
@@ -101,7 +101,7 @@ liftContext :: TaffyIO a -> WorkspacesIO a
 liftContext action = asks taffyContext >>= lift . runReaderT action
 
 liftX11Def :: a -> X11Property a -> WorkspacesIO a
-liftX11Def def prop = liftContext $ runX11Def def prop
+liftX11Def dflt prop = liftContext $ runX11Def dflt prop
 
 setWorkspaceWidgetStatusClass ::
      (MonadIO m, Gtk.IsWidget a) => Workspace -> a -> m ()

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -39,6 +39,7 @@ library
                , conduit
                , containers
                , coinbase-pro >= 0.9.2.2 && < 1.0.0.0
+               , data-default
                , dbus >= 1.2.11 && < 2.0.0
                , dbus-hslogger >= 0.1.0.1 && < 0.2.0.0
                , directory

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -169,6 +169,7 @@ library
 executable taffybar
   default-language: Haskell2010
   build-depends: base > 3 && < 5
+               , data-default
                , directory
                , hslogger
                , optparse-applicative


### PR DESCRIPTION
Fixes #518

I'm not sure which of the last five commits should be merged, but I put them here so it can be decided. The first two of them update the examples to use `def` where possible, the third updates the executable to use it, and the last two change argument names which were previously `def` and made GHC emit a warning for shadowing with the importing of `Data.Default.def`.

There are also several defaults exported which cannot be replaced with `def` because they are not simple data types but rather functions or type aliases. Notably, `defaultMPRIS2Config :: MPRIS2Config MPRIS2PlayerWidget` can technically be done but would require `FlexibleInstances` and for the user to supply additional type information at the use site (with an annotation or type application), so I left it out.

If it's all good I can squash it down to one commit for merging.