### PR TITLE
Fixed compilation errors for GHC-9.0.1

### DIFF
--- a/src/System/Taffybar/Context.hs
+++ b/src/System/Taffybar/Context.hs
@@ -87,7 +87,7 @@ logC :: MonadIO m => System.Log.Logger.Priority -> String -> m ()
 logC p = liftIO . logIO p
 
 -- | 'Taffy' is a monad transformer that provides 'Reader' for 'Context'.
-type Taffy m v = MonadIO m => ReaderT Context m v
+type Taffy m v = ReaderT Context m v
 
 -- | 'TaffyIO' is 'IO' wrapped with a 'ReaderT' providing 'Context'. This is the
 -- type of most widgets and callback in taffybar.
@@ -226,7 +226,7 @@ buildContext TaffybarConfig
                 }
   _ <- runMaybeT $ MaybeT GI.Gdk.displayGetDefault >>=
               (lift . GI.Gdk.displayGetDefaultScreen) >>=
-              (lift . flip GI.Gdk.afterScreenMonitorsChanged
+              (lift . (\x y -> GI.Gdk.afterScreenMonitorsChanged y x)
                -- XXX: We have to do a force refresh here because there is no
                -- way to reliably move windows, since the window manager can do
                -- whatever it pleases.

--- a/src/System/Taffybar/Widget/Windows.hs
+++ b/src/System/Taffybar/Widget/Windows.hs
@@ -79,7 +79,7 @@ windowsNew config = do
   subscription <-
     subscribeToPropertyEvents [ewmhActiveWindow, ewmhWMName, ewmhWMClass]
                       activeWindowUpdatedCallback
-  _ <- liftReader (Gtk.onWidgetUnrealize label) (unsubscribe subscription)
+  _ <- liftReader (\x -> Gtk.onWidgetUnrealize label x) (unsubscribe subscription)
 
   context <- ask
 


### PR DESCRIPTION
I'm not sure why the `MonadIO m` constraint for the `Taffy` type synonym was needed; it didn't seem necessary to me, but there were compilation errors until I removed it.

The other changes, related to eta-expansion in association with implicit-param functions, are necessary because of simplified subsumption in GHC 9.0.1. https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#compiler-changes