### PR TITLE
Change Dyre to 0.9

### DIFF
--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -43,7 +43,7 @@ library
                , dbus >= 1.2.11 && < 2.0.0
                , dbus-hslogger >= 0.1.0.1 && < 0.2.0.0
                , directory
-               , dyre >= 0.8.6 && < 0.10
+               , dyre >= 0.9.0 && < 0.10
                , either >= 4.0.0.0
                , enclosed-exceptions >= 1.0.0.1
                , filepath


### PR DESCRIPTION
I noticed a small issue in the .cabal file; it still says that Dyre 0.8.6 is usable, but attempting to build with that version doesn't seem to work.

It looks like Dyre 0.8 lacks Dyre.newParam, which is used in this project, 0.9 should work fine.