### PR TITLE
Add cabal flag so that the crypto assets widget can be disabled

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 if type lorri &>/dev/null; then
     eval "$(lorri direnv)"
 else
-    use nix
+    use flake
 fi

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,3 @@
 packages: ./
+
+allow-newer: coinbase-pro:memory

--- a/src/System/Taffybar/Widget.hs
+++ b/src/System/Taffybar/Widget.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module System.Taffybar.Widget
   ( module System.Taffybar.Widget.Util
   -- * "System.Taffybar.Widget.Battery"
@@ -9,8 +11,10 @@ module System.Taffybar.Widget
   -- * "System.Taffybar.Widget.CommandRunner"
   , module System.Taffybar.Widget.CommandRunner
 
+#ifdef WIDGET_CRYPTO
   -- * "System.Taffybar.Widget.Crypto"
   , module System.Taffybar.Widget.Crypto
+#endif
 
   -- * "System.Taffybar.Widget.DiskIOMonitor"
   , module System.Taffybar.Widget.DiskIOMonitor
@@ -64,7 +68,9 @@ module System.Taffybar.Widget
 import System.Taffybar.Widget.Battery
 import System.Taffybar.Widget.CPUMonitor
 import System.Taffybar.Widget.CommandRunner
+#ifdef WIDGET_CRYPTO
 import System.Taffybar.Widget.Crypto
+#endif
 import System.Taffybar.Widget.DiskIOMonitor
 import System.Taffybar.Widget.FSMonitor
 import System.Taffybar.Widget.FreedesktopNotifications

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -21,6 +21,10 @@ extra-source-files:
   dbus-xml/org.mpris.MediaPlayer2.Player.xml
   dbus-xml/org.mpris.MediaPlayer2.xml
 
+flag cryptocurrency
+    description: Enable crypto assets widget.
+    default: True
+
 library
   default-extensions:
     TupleSections
@@ -32,13 +36,11 @@ library
                , ConfigFile
                , HStringTemplate >= 0.8 && < 0.9
                , X11 >= 1.5.0.1
-               , aeson
                , ansi-terminal
                , broadcast-chan >= 0.2.0.2
                , bytestring
                , conduit
                , containers
-               , coinbase-pro >= 0.9.2.2 && < 1.0.0.0
                , data-default
                , dbus >= 1.2.11 && < 2.0.0
                , dbus-hslogger >= 0.1.0.1 && < 0.2.0.0
@@ -106,7 +108,6 @@ library
                  , System.Taffybar.Information.CPU
                  , System.Taffybar.Information.CPU2
                  , System.Taffybar.Information.Chrome
-                 , System.Taffybar.Information.Crypto
                  , System.Taffybar.Information.DiskIO
                  , System.Taffybar.Information.EWMHDesktopInfo
                  , System.Taffybar.Information.MPRIS2
@@ -124,7 +125,6 @@ library
                  , System.Taffybar.Widget.Battery
                  , System.Taffybar.Widget.CPUMonitor
                  , System.Taffybar.Widget.CommandRunner
-                 , System.Taffybar.Widget.Crypto
                  , System.Taffybar.Widget.DiskIOMonitor
                  , System.Taffybar.Widget.FSMonitor
                  , System.Taffybar.Widget.FreedesktopNotifications
@@ -155,6 +155,13 @@ library
                  , System.Taffybar.Widget.XDGMenu.Menu
                  , System.Taffybar.Widget.XDGMenu.MenuWidget
                  , System.Taffybar.WindowIcon
+
+  if flag(cryptocurrency)
+    build-depends: coinbase-pro >= 0.9.2.2 && < 1.0.0.0
+                 , aeson
+    exposed-modules: System.Taffybar.Information.Crypto
+                   , System.Taffybar.Widget.Crypto
+    cpp-options: -DWIDGET_CRYPTO
                    
   other-modules: Paths_taffybar
                , System.Taffybar.DBus.Client.MPRIS2


### PR DESCRIPTION
This PR is trying to fix the taffybar nix package which has been marked broken in the latest `nixos-unstable` channel.

I have nothing against crypto assets or the widget, but the required [coinbase-pro](https://hackage.haskell.org/package/coinbase-pro) package has a few conflicts with [aeson >= 2.0](https://hackage.haskell.org/package/aeson-2.0.3.0).

So for now, until this dependency is updated, it seems easiest and best to just add a cabal flag so that taffybar can be built with newer Stackage LTS versions.