### PR TITLE
Add CLI option `--project-name`/`-p` to customize taffybar configuration location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist/
+/dist-newstyle/
 .stack-work
 .cabal-sandbox
 cabal.sandbox.config

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -158,7 +158,7 @@ library
                  , System.Taffybar.Widget.XDGMenu.Menu
                  , System.Taffybar.Widget.XDGMenu.MenuWidget
                  , System.Taffybar.WindowIcon
-                   
+
   other-modules: Paths_taffybar
                , System.Taffybar.DBus.Client.MPRIS2
                , System.Taffybar.DBus.Client.Params
@@ -176,6 +176,8 @@ executable taffybar
                , directory
                , hslogger
                , optparse-applicative
+               , dyre
+               , xdg-basedir
                , taffybar
 
   other-modules: Paths_taffybar


### PR DESCRIPTION
Commits:

- gitignore: add dist-newstyle
- taffybar.cabal: expose dyre, xdg-basedir as direct dependencies
- app/Main.hs: add CLI option to customize dyre project name

Resolves #552.

Intended to used like so:

```bash
taffybar --project-name=PROJECTNAME
```

By default, when the option is omitted, the behavior is `--project-name=taffybar`. This launches the taffybar configuration defined at `$XDG_CONFIG_HOME/taffybar/taffybar.hs`, which is the existing behavior.

Meanwhile, if I wanted to define and run another bar instance, I could place it at `$XDG_CONFIG_HOME/taffybar-alt/taffybar-alt.hs`, and then run

```bash
taffybar --project-name=taffybar-alt
```

If I wanted to reuse library/source code across the two definitions, I can define the two bars in the same folder, then add a symlink `taffybar-alt`→`taffybar`.
