### PR TITLE
Allow scotty 0.12

### DIFF
--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -72,7 +72,7 @@ library
                , rate-limit >= 1.1.1
                , regex-compat
                , safe >= 0.3 && < 1
-               , scotty >= 0.11.0 && < 0.12.0
+               , scotty >= 0.11 && < 0.13
                , split >= 0.1.4.2
                , status-notifier-item >= 0.3.1.0
                , stm


### PR DESCRIPTION
Tested to build fine with scotty 0.12/0.12.1.

Removed the third part of version because 0.12 < 0.12.0, which isn't obvious and causes confusion.