### PR TITLE
css: Remove misleading precision

### DIFF
--- a/taffybar.css
+++ b/taffybar.css
@@ -1,4 +1,4 @@
-@define-color transparent rgba(0.0, 0.0, 0.0, 0.0);
+@define-color transparent rgba(0, 0, 0, 0.0);
 @define-color white #FFFFFF;
 @define-color black #000000;
 @define-color taffy-blue #0c7cd5;
@@ -25,7 +25,7 @@
 
 .taffy-box {
 	border-radius: 10px;
-	background-color: rgba(0.0, 0.0, 0.0, 0.3);
+	background-color: rgba(0, 0, 0, 0.3);
 }
 
 .inner-pad {
@@ -53,11 +53,11 @@
 }
 
 .active .contents {
-	background-color: rgba(0.0, 0.0, 0.0, 0.5);
+	background-color: rgba(0, 0, 0, 0.5);
 }
 
 .visible .contents {
-	background-color: rgba(0.0, 0.0, 0.0, 0.2);
+	background-color: rgba(0, 0, 0, 0.2);
 }
 
 .window-icon-container {


### PR DESCRIPTION
The colour components of `rgba(...)` expressions
are integers (that is, range from 0 to 255). The syntax previously used suggested that they were rather
floats (0-1), leading to quite a bit of head-scratching when colours did not render as expected.