### PR TITLE
Allow scotty 0.21

### DIFF
--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -72,7 +72,7 @@ library
                , rate-limit >= 1.1.1
                , regex-compat
                , safe >= 0.3 && < 1
-               , scotty >= 0.11 && < 0.21
+               , scotty >= 0.11 && < 0.22
                , split >= 0.1.4.2
                , status-notifier-item >= 0.3.1.0
                , stm


### PR DESCRIPTION
It builds fine with scotty 0.21, thanks.

Also would it be possible to get a Hackage cabal file revision on 4.0.1 and/or a release? So that the taffybar package works on nixpkgs → https://github.com/NixOS/nixpkgs/pull/279413

