### PR TITLE
withBatteryRefresh: Improve docs and reduce log spam

### DIFF
--- a/src/System/Taffybar/Hooks.hs
+++ b/src/System/Taffybar/Hooks.hs
@@ -58,8 +58,13 @@ setTaffyLogFormatter loggerName = do
   handler <- taffyLogHandler
   updateGlobalLogger loggerName $ setHandlers [handler]
 
--- | Add 'refreshrefreshBatteriesOnPropChange' to the 'startupHook' of the
--- provided 'TaffybarConfig'.
+-- | Add 'refreshBatteriesOnPropChange' to the 'startupHook' of the
+-- provided 'TaffybarConfig'. Use this if your system has issues with
+-- the battery widget not updating or reporting the incorrect state.
+--
+-- This function 'withBatteryRefresh' is __not normally needed__
+-- because the battery widget already subscribes to updates from
+-- UPower, and UPower usually works correctly.
 withBatteryRefresh :: TaffybarConfig -> TaffybarConfig
 withBatteryRefresh = appendHook refreshBatteriesOnPropChange
 


### PR DESCRIPTION
This PR addresses issue #568, thanks.

1. Clarify the documentation about `withBatteryRefresh`. This function usually isn't needed, though it is used in the `Example.hs` config.

2. Fix the `PropertiesChanged` signal filtering. I was seeing updates coming from systemd-networkd, UDisks2, everything (This may be due to me using dbus-broker; I'm not really sure).

3. As far as I can tell, the UPower `Refresh()` method is going to fail pretty much [all the time][1]. So there's no need to log an ERROR message at all, much less repeatedly.

[1]: https://upower.freedesktop.org/docs/Device.html#Device.Refresh