### PR TITLE
Reduce log level of System.Taffybar.WindowIcon - Multiple entries

### DIFF
--- a/src/System/Taffybar/WindowIcon.hs
+++ b/src/System/Taffybar/WindowIcon.hs
@@ -29,6 +29,7 @@ import           System.Taffybar.Information.X11DesktopInfo
 import           System.Environment.XDG.DesktopEntry
 import           System.Taffybar.Util
 import           System.Taffybar.Widget.Util
+import           Text.Printf
 
 type ColorRGBA = Word32
 
@@ -100,9 +101,10 @@ getDirectoryEntryByClass
   -> TaffyIO (Maybe DesktopEntry)
 getDirectoryEntryByClass klass = do
   entries <- MM.lookup klass <$> getDirectoryEntriesByClassName
-  when (length entries > 1) $
-       logPrintF "System.Taffybar.WindowIcon" INFO "Multiple entries for: %s"
-       (klass, entries)
+  when (length entries > 1) $ liftIO $
+       logM "System.Taffybar.WindowIcon" DEBUG $ printf
+         "Class \"%s\" has multiple desktop entries: %s"
+         klass (intercalate ", " $ map deFilename entries)
   return $ listToMaybe entries
 
 getWindowIconForAllClasses


### PR DESCRIPTION
On my system, I get *a lot* of these log messages. There's not much I can do to fix whatever overlapping desktop files appear in `$XDG_DATA_DIRS`. The multiple entries are usually identical; if not identical then they have the same icon. The log messages dump way too much data. They seem like they should be at DEBUG level rather than INFO.