### PR TITLE
Correctly handle Ctrl-C

### DIFF
--- a/src/System/Taffybar/DBus/Toggle.hs
+++ b/src/System/Taffybar/DBus/Toggle.hs
@@ -142,7 +142,7 @@ exportTogglesInterface = do
           , autoMethod "showOnMonitor" $
             takeInt $ toggleTaffyOnMon (const True)
           , autoMethod "refresh" $ runReaderT refreshTaffyWindows ctx
-          , autoMethod "exit" (Gtk.mainQuit :: IO ())
+          , autoMethod "exit" $ exitTaffybar ctx
           ]
         }
   lift $ do


### PR DESCRIPTION
This change lets Taffybar promptly exit after Ctrl-C is pressed.

With gi-gtk apps, the normal SIGINT handler which throws `UserInterrupt` is either overwritten by Gtk, or the async exception gets swallowed within the main loop. I'm not sure which, but in either case we need to do something about it.
 
Previously, it was relying on the GHC runtime system to exit after the first SIGINT was ignored. That's why you need to press Ctrl-C twice to exit Taffybar.

This change also makes sure Taffybar top-level windows are destroyed before exiting.

Normally it doesn't matter if windows aren't destroyed before exiting. The default close-down mode for an X connection is `DestroyAll`. Exiting the process will close the X connection, which will lead to the resources being destroyed by the X server.
    
However, I would like to run Taffybar from within GHCi. In this environment, Ctrl-C will terminate `startTaffybar`, but the actual process (ghci) remains to receive further commands. If Taffybar windows aren't destroyed, they become unresponsive zombie Taffybars sitting in the way.

Running `startTaffybar` twice within a single GHCi session will still crash, unfortunately. I am working on some more changes (another PR) to allow reloading and restarting Taffybar from GHCi.