### PR TITLE
flake.nix: Build for multiple compiler versions, add checks

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+watch_file taffybar.cabal nix/*.nix
 use flake .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lints:
-    name: Build
+    name: Build and Check
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -16,3 +16,20 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Run `nix build`
         run: nix build .
+      - name: Run `nix flake check`
+        run: nix flake check
+
+  build:
+    name: Build with ${{ matrix.compiler }}
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        compiler: [ghc94]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+      - name: Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Nix build for ${{ matrix.compiler }}
+        run: nix build .#${{ matrix.compiler }}-taffybar

--- a/flake.lock
+++ b/flake.lock
@@ -5,55 +5,21 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "git-ignore-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "ref": "master",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "gtk-sni-tray": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "git-ignore-nix": [
-          "git-ignore-nix"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "status-notifier-item": [
-          "status-notifier-item"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1663379298,
         "narHash": "sha256-m18+G7V1N+g/pPeKJG9hkblGA5c8QTnUYnsU5t14sOw=",
@@ -70,17 +36,7 @@
       }
     },
     "gtk-strut": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "git-ignore-nix": [
-          "git-ignore-nix"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1663377859,
         "narHash": "sha256-UrBd+R3NaJIDC2lt5gMafS3KBeLs83emm2YorX2cFCo=",
@@ -115,7 +71,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "git-ignore-nix": "git-ignore-nix",
         "gtk-sni-tray": "gtk-sni-tray",
         "gtk-strut": "gtk-strut",
         "nixpkgs": "nixpkgs",
@@ -124,17 +79,7 @@
       }
     },
     "status-notifier-item": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "git-ignore-nix": [
-          "git-ignore-nix"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1641783528,
         "narHash": "sha256-wJymJfYPFj4/r1e4kT/wt9FEsyCXo5JkkcOoozpuhag=",
@@ -165,26 +110,13 @@
       }
     },
     "xmonad": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "git-ignore-nix": [
-          "git-ignore-nix"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "unstable": [
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
-        "lastModified": 1722277235,
-        "narHash": "sha256-fuEgR51OPzwff+ygFhBqJm51oA17rR0KtPfuDLv0Fp0=",
+        "lastModified": 1726451364,
+        "narHash": "sha256-6WKgYq0+IzPSXxVl1MfODIVwEbd3Sw0zc5sMSOyzA8I=",
         "owner": "xmonad",
         "repo": "xmonad",
-        "rev": "a58ccac7ba46414915de6c7f2b4da08b37784016",
+        "rev": "a4140b93497333ec7f3127ee4dabcb8ae8a721b6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,73 +1,56 @@
 {
   inputs = {
-    flake-utils.url = github:numtide/flake-utils;
-    git-ignore-nix = {
-      url = github:hercules-ci/gitignore.nix/master;
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
     gtk-sni-tray = {
-      url = github:taffybar/gtk-sni-tray/master;
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-      inputs.git-ignore-nix.follows = "git-ignore-nix";
-      inputs.status-notifier-item.follows = "status-notifier-item";
+      url = "github:taffybar/gtk-sni-tray/master";
+      flake = false;
     };
     gtk-strut = {
-      url = github:taffybar/gtk-strut/master;
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-      inputs.git-ignore-nix.follows = "git-ignore-nix";
+      url = "github:taffybar/gtk-strut/master";
+      flake = false;
     };
     xmonad = {
-      url = github:xmonad/xmonad/master;
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.unstable.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-      inputs.git-ignore-nix.follows = "git-ignore-nix";
+      url = "github:xmonad/xmonad/master";
+      flake = false;
     };
     status-notifier-item = {
-      url = github:taffybar/status-notifier-item;
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-      inputs.git-ignore-nix.follows = "git-ignore-nix";
-    };
-    nixpkgs = {
-      url = github:NixOS/nixpkgs/nixos-unstable;
+      url = "github:taffybar/status-notifier-item";
+      flake = false;
     };
   };
 
-  outputs = { self, flake-utils, nixpkgs, git-ignore-nix, gtk-sni-tray, gtk-strut, status-notifier-item, xmonad }: let
-    inherit (nixpkgs) lib;
+  outputs = { self, nixpkgs, flake-utils, gtk-sni-tray, gtk-strut, status-notifier-item, xmonad }: let
+    inherit (self) lib;
+    inherit (nixpkgs.lib) composeExtensions;
+
+    # This flake will generate packages using the following compilers
+    # from nixpkgs. The "default" package in this flake will be built with
+    # the whichever GHC nixpkgs uses to generate pkgs.haskellPackages.
+    # Currently in nixpkgs: haskellPackages = haskell.packages.ghc96
+    supportedCompilers = [ "ghc94" "ghc96" "ghc98" ];
+
   in {
-    # Define a haskellPackages overlay with taffybar added.
-    hoverlay = final: prev: let
-      haskellLib = final.haskell.lib.compose;
-      inherit (haskellLib) packageSourceOverrides;
-    in
-      lib.composeExtensions
-        (packageSourceOverrides {
-          # This package, with non-git files filtered out to reduce
-          # unnecessary rebuilds.
-          taffybar = git-ignore-nix.lib.gitignoreSource ./.;
-          # Example project
-          my-taffybar = git-ignore-nix.lib.gitignoreSource ./example;
-          # Dependencies which we want to build from source.
-          # These are flake inputs.
-          inherit gtk-strut gtk-sni-tray status-notifier-item xmonad;
-        })
-        (self: super: {
-          # Add further customization of haskellPackages here
-          taffybar = self.generateOptparseApplicativeCompletions [ "taffybar" ] super.taffybar;
+    lib = nixpkgs.lib.extend (composeExtensions
+      (import ./nix/lib-overlay.nix)
+      (final: prev: {
+        taffybar = prev.taffybar.extend (final: prev: {
+          sourceOverrides = prev.sourceOverrides // {
+            # Flake input dependencies which we want to build from source.
+            inherit gtk-strut gtk-sni-tray status-notifier-item xmonad;
+          };
         });
+      }));
 
     # Make a nixpkgs overlay using the above haskellPackages overlay.
-    overlays.default = final: prev: {
-      haskell = prev.haskell // {
-        packageOverrides = lib.composeExtensions
-          prev.haskell.packageOverrides
-          (self.hoverlay final prev);
-      };
-    };
+    overlays.default = composeExtensions
+      (import ./nix/overlay.nix)
+      (final: prev: {
+        lib = prev.lib.extend (final: prev: {
+          # Use lib.taffybar from this flake
+          inherit (self.lib) taffybar;
+        });
+      });
 
   } // flake-utils.lib.eachDefaultSystem (system: let
     pkgs = import nixpkgs {
@@ -75,34 +58,26 @@
       overlays = [ self.overlays.default ];
       config.allowBroken = true;
     };
-    haskellPackages = pkgs.haskell.packages.ghc96;
 
   in {
-    devShells.default = (haskellPackages.shellFor {
-      packages = p: [ p.taffybar p.my-taffybar ];
-
-      # Add some development tools to the shell.
-      nativeBuildInputs = [
-        pkgs.cabal-install
-        pkgs.haskell-language-server
-      ] ++ (with haskellPackages; [
-        hlint ormolu implicit-hie hie-bios
-      ]);
-
-    }).overrideAttrs (oldAttrs: {
-      # This is required so that "cabal repl" and haskell-language-server
-      # can find non-pkgconfig dependencies.
-      shellHook = ''
-        ${oldAttrs.shellHook or ""}
-        export LD_LIBRARY_PATH=${lib.makeLibraryPath [ pkgs.zlib ]}:$LD_LIBRARY_PATH
-      '';
-    });
+    devShells = {
+      default = import ./nix/shell.nix { inherit pkgs; };
+    } // lib.genAttrs supportedCompilers
+      (compiler: pkgs.haskell.packages.${compiler}.taffybar.env);
 
     packages = {
       default = self.packages.${system}.taffybar;
-      inherit (haskellPackages)
+      inherit (pkgs.haskellPackages)
         taffybar
         my-taffybar;
+    } // lib.listToAttrs (map (compiler: {
+      name = "${compiler}-taffybar";
+      value = pkgs.haskell.packages.${compiler}.taffybar;
+    }) supportedCompilers);
+
+    checks = {
+      hlint = pkgs.haskellPackages.taffybar.hlint;
+      ghc-warnings = pkgs.haskellPackages.taffybar.fail-on-all-warnings;
     };
   });
 

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
         })
         (self: super: {
           # Add further customization of haskellPackages here
+          taffybar = self.generateOptparseApplicativeCompletions [ "taffybar" ] super.taffybar;
         });
 
     # Make a nixpkgs overlay using the above haskellPackages overlay.

--- a/flake.nix
+++ b/flake.nix
@@ -104,4 +104,9 @@
         my-taffybar;
     };
   });
+
+  nixConfig = {
+    extra-substituters = [ "https://haskell-language-server.cachix.org" ];
+    extra-trusted-public-keys = [ "haskell-language-server.cachix.org-1:juFfHrwkOxqIOZShtC4YC1uT1bBcq2RSvC7OMKx0Nz8=" ];
+  };
 }

--- a/nix/haskell-package-overrides.nix
+++ b/nix/haskell-package-overrides.nix
@@ -1,0 +1,77 @@
+# This file defines an overlay for haskellPackages.
+#
+# Haskell package sources are given in the "sourceOverrides" argument.
+{ sourceOverrides }:
+
+# Then, to produce the actual overlay for haskellPackages, it must be
+# applied to the "final" and "prev" args of a nixpkgs overlay.
+final: prev: let
+  pkgs = final;
+  inherit (pkgs) lib;
+
+  haskellLib = pkgs.haskell.lib.compose;
+
+  # Add further customization of haskellPackages here
+  configuration = with haskellLib; self: super: {
+    taffybar = lib.pipe super.taffybar [
+      (self.generateOptparseApplicativeCompletions [ "taffybar" ])
+      (overrideCabal (drv: {
+        # This is required so that "cabal repl" and haskell-language-server
+        # can find non-pkgconfig dependencies.
+        shellHook = ''
+          ${drv.shellHook or ""}
+          export LD_LIBRARY_PATH=${lib.makeLibraryPath [ pkgs.zlib ]}:$LD_LIBRARY_PATH
+        '';
+      }))
+
+      # Add checks as passthru attributes
+      (overrideCabal (drv: {
+        passthru = drv.passthru // rec {
+          fail-on-all-warnings = self.taffybar-fail-on-all-warnings;
+
+          # Generates the HLint report but won't fail if there are hints.
+          hlint-report = pkgs.runCommand "${drv.pname}-hlint-${drv.version}" {
+            inherit (drv) src;
+            nativeBuildInputs = [ pkgs.hlint ];
+          } ''
+            cd $src
+            mkdir $out
+            hlint . -j$NIX_BUILD_CORES --report=$out/report.html --no-exit-code --json > $out/report.json
+          '';
+
+          # Reads the above HLint report and fails if there are hints.
+          hlint = pkgs.runCommand "${drv.pname}-check-hlint-${drv.version}" {
+            src = hlint-report;
+            nativeBuildInputs = [ pkgs.jq ];
+          } ''
+            echo "Checking $src/report.json"
+            jq -r 'length|if .==0 then "No hints." else "\(.) hint\(if .>1 then "s" else "" end).\n"|halt_error end' < $src/report.json
+            ln -s $src $out
+         '';
+        };
+      }))
+    ];
+
+    taffybar-fail-on-all-warnings = lib.pipe self.taffybar [
+      failOnAllWarnings
+      # Use a different name so we don't confuse it with the normal build.
+      (overrideCabal (drv: { pname = "fail-on-all-warnings-${drv.pname}"; }))
+      # Various tricks to try and make the build quicker.
+      dontHaddock
+      disableLibraryProfiling
+      disableSharedLibraries
+      disableSharedExecutables
+      (appendBuildFlag "--ghc-options=-c")  # compile but don't link
+      (overrideCabal (drv: {
+        checkPhase = "";
+        enableSeparateDataOutput = false;
+        installPhase = "";
+        postInstall = "";
+        preFixup = "";
+      }))
+    ];
+  };
+in
+  lib.composeExtensions
+    (haskellLib.packageSourceOverrides sourceOverrides)
+    configuration

--- a/nix/lib-overlay.nix
+++ b/nix/lib-overlay.nix
@@ -1,0 +1,31 @@
+# This is an overlay for nixpkgs.lib.
+# The most important part is lib.taffybar.haskellPackageOverrides
+# which provides an overlay for haskellPackages.
+
+final: prev: let lib = final; in {
+  taffybar = lib.makeExtensible (taffybarFinal: {
+    # Define a haskellPackages overlay with taffybar added.
+    haskellPackageOverrides = import ./haskell-package-overrides.nix {
+      inherit (taffybarFinal) sourceOverrides;
+    };
+
+    sourceOverrides = {
+      # This package, with non-Haskell files filtered out to
+      # reduce unnecessary rebuilds.
+      taffybar = lib.fileset.toSource {
+        root = ../.;
+        fileset = lib.fileset.fileFilter lib.taffybar.taffyFileFilter ../.;
+      };
+      # Example project
+      my-taffybar = ../example;
+    };
+
+    haskellFilesFilter = file:
+      lib.lists.any file.hasExt [ "cabal" "hs" "lhs" ] ||
+      lib.strings.hasPrefix "LICENSE" file.name;
+    taffyExtraFilesFilter = file:
+      lib.lists.any file.hasExt [ "md" "css" "svg" "xml" ];
+    taffyFileFilter = file: final.taffybar.haskellFilesFilter file ||
+                            final.taffybar.taffyExtraFilesFilter file;
+  });
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,11 @@
+# A nixpkgs overlay which provides haskellPackages.taffybar.
+
+final: prev: {
+  lib = prev.lib.extend (import ./lib-overlay.nix);
+
+  haskell = prev.haskell // {
+    packageOverrides = final.lib.composeExtensions
+      prev.haskell.packageOverrides
+      (final.lib.taffybar.haskellPackageOverrides final prev);
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> { overlays = [ (import ./overlay.nix) ]; } }:
+
+pkgs.haskellPackages.shellFor {
+  packages = p: [ p.taffybar p.my-taffybar ];
+
+  withHoogle = true;
+
+  # Add some development tools to the shell.
+  nativeBuildInputs = [
+    pkgs.cabal-install
+    pkgs.haskell-language-server
+  ] ++ (with pkgs.haskellPackages; [
+    hlint ormolu implicit-hie hie-bios
+  ]);
+
+  inherit (pkgs.haskellPackages.taffybar.env) shellHook;
+}


### PR DESCRIPTION
1. Adds flake outputs building taffybar against defined ghc versions from nixpkgs.
2. Adds some flake checks for HLint, `-Werror`.
3. Splits the nixpkgs overlay into a separate `overlay.nix` which can be consumed by non-flake projects.
4. Puts back the cachix settings in `flake.nix`.
5. Update the github actions workflow to build more stuff.
