### PR TITLE
Deprecate System.Taffybar.Support.PagerHints

### DIFF
--- a/example/my-taffybar.cabal
+++ b/example/my-taffybar.cabal
@@ -12,3 +12,13 @@ executable my-taffybar
   build-depends:       base
                      , taffybar
   default-language:    Haskell2010
+
+executable my-xmonad
+  hs-source-dirs:      .
+  main-is:             xmonad.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , data-default
+                     , xmonad
+                     , xmonad-contrib
+  default-language:    Haskell2010

--- a/example/xmonad.hs
+++ b/example/xmonad.hs
@@ -1,9 +1,10 @@
 module Main where
 
+import           Data.Default                    (def)
 import           XMonad
-import           XMonad.Hooks.EwmhDesktops        (ewmh)
+import           XMonad.Hooks.EwmhDesktops       (ewmh)
 import           XMonad.Hooks.ManageDocks
-import           System.Taffybar.Support.PagerHints (pagerHints)
+import           XMonad.Hooks.TaffybarPagerHints (pagerHints)
 
 main = xmonad $
        -- docks allows xmonad to handle taffybar
@@ -12,4 +13,5 @@ main = xmonad $
        ewmh $
        -- pagerHints supplies additional state that is not supplied by ewmh
        pagerHints
-       defaultConfig
+       -- Apply these to the default XMonad config
+       def

--- a/src/System/Taffybar/Information/X11DesktopInfo.hs
+++ b/src/System/Taffybar/Information/X11DesktopInfo.hs
@@ -9,10 +9,11 @@
 -- Portability : unportable
 --
 -- Low-level functions to access data provided by the X11 desktop via window
--- properties. One of them ('getVisibleTags') depends on the PagerHints hook
+-- properties. One of them ('getVisibleTags') depends on the
+-- 'XMonad.Hooks.TaffybarPagerHints.pagerHints' hook
 -- being installed in your @~\/.xmonad\/xmonad.hs@ configuration:
 --
--- > import System.Taffybar.Support.PagerHints (pagerHints)
+-- > import XMonad.Hooks.TaffybarPagerHints (pagerHints)
 -- >
 -- > main = xmonad $ ewmh $ pagerHints $ ...
 --
@@ -141,10 +142,11 @@ isWindowUrgent window = do
   hints <- fetchWindowHints window
   return $ testBit (wmh_flags hints) urgencyHintBit
 
--- | Retrieve the value of the special _XMONAD_VISIBLE_WORKSPACES hint set by
--- the PagerHints hook provided by Taffybar (see module documentation for
--- instructions on how to do this), or an empty list of strings if the
--- PagerHints hook is not available.
+-- | Retrieve the value of the special @_XMONAD_VISIBLE_WORKSPACES@
+-- hint set by the 'XMonad.Hooks.TaffybarPagerHints.pagerHints' hook
+-- provided by [xmonad-contrib]("XMonad.Hooks.TaffybarPagerHints")
+-- (see module documentation for instructions on how to do this), or
+-- an empty list of strings if the @pagerHints@ hook is not available.
 getVisibleTags :: X11Property [String]
 getVisibleTags = readAsListOfString Nothing "_XMONAD_VISIBLE_WORKSPACES"
 

--- a/src/System/Taffybar/Support/PagerHints.hs
+++ b/src/System/Taffybar/Support/PagerHints.hs
@@ -5,7 +5,7 @@
 -- License     : BSD3-style (see LICENSE)
 --
 -- Maintainer  : José A. Romero L. <escherdragon@gmail.com>
--- Stability   : unstable
+-- Stability   : deprecated
 -- Portability : unportable
 --
 -- Complements the "XMonad.Hooks.EwmhDesktops" with two additional hints
@@ -30,11 +30,12 @@
 --
 -----------------------------------------------------------------------------
 
-module System.Taffybar.Support.PagerHints (
+module System.Taffybar.Support.PagerHints
+  {-# DEPRECATED "Use XMonad.Hooks.TaffybarPagerHints instead" #-} (
   -- * Usage
   -- $usage
   pagerHints
-) where
+  ) where
 
 import Codec.Binary.UTF8.String (encode)
 import Control.Monad

--- a/src/System/Taffybar/Widget/Layout.hs
+++ b/src/System/Taffybar/Widget/Layout.hs
@@ -37,10 +37,10 @@ import           System.Taffybar.Widget.Util
 
 -- $usage
 --
--- This widget requires that the "System.Taffybar.Support.PagerHints" hook be
+-- This widget requires that the "XMonad.Hooks.TaffybarPagerHints" hook be
 -- installed in your @xmonad.hs@:
 --
--- > import System.Taffybar.Support.PagerHints (pagerHints)
+-- > import XMonad.Hooks.TaffybarPagerHints (pagerHints)
 -- > main = do
 -- >   xmonad $ ewmh $ pagerHints $ defaultConfig
 -- > ...

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -21,6 +21,9 @@ extra-source-files:
   dbus-xml/org.mpris.MediaPlayer2.Player.xml
   dbus-xml/org.mpris.MediaPlayer2.xml
 
+flag DeprecatedPagerHints
+  description: Enables the deprecated System.Taffybar.Support.PagerHints module, which has been moved to xmonad-contrib.
+
 library
   default-extensions:
     TupleSections
@@ -89,7 +92,6 @@ library
                , xdg-basedir >= 0.2 && < 0.3
                , xml
                , xml-helpers
-               , xmonad
 
   hs-source-dirs: src
   pkgconfig-depends: gtk+-3.0
@@ -116,7 +118,6 @@ library
                  , System.Taffybar.Information.XDG.Protocol
                  , System.Taffybar.LogFormatter
                  , System.Taffybar.SimpleConfig
-                 , System.Taffybar.Support.PagerHints
                  , System.Taffybar.Util
                  , System.Taffybar.Widget
                  , System.Taffybar.Widget.Battery
@@ -153,6 +154,10 @@ library
                  , System.Taffybar.Widget.XDGMenu.Menu
                  , System.Taffybar.Widget.XDGMenu.MenuWidget
                  , System.Taffybar.WindowIcon
+
+  if flag(DeprecatedPagerHints)
+    build-depends: xmonad
+    exposed-modules: System.Taffybar.Support.PagerHints
 
   other-modules: Paths_taffybar
                , System.Taffybar.DBus.Client.MPRIS2


### PR DESCRIPTION
Deprecates the `System.Taffybar.Support.PagerHints` module because it is available in xmonad-contrib per #292 / #480 / xmonad/xmonad-contrib#579.

Adds a cabal flag to support fully removing the deprecated module at some future date.

Resolves #526.
