### PR TITLE
Add GHC 9.2 to CI matrix

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,11 +37,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ghc94, ghc98]
+        compiler: [ghc92, ghc94, ghc98]
         experimental: [false]
         # include:
-        #   - compiler: ghc92
-        #     experimental: true
         #   - compiler: ghc910
         #     experimental: true
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725634671,
-        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
+        "lastModified": 1728888510,
+        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     "xmonad": {
       "flake": false,
       "locked": {
-        "lastModified": 1726451364,
-        "narHash": "sha256-6WKgYq0+IzPSXxVl1MfODIVwEbd3Sw0zc5sMSOyzA8I=",
+        "lastModified": 1728318022,
+        "narHash": "sha256-JYDe/lNgfiWl+QXZDtaLuU3sscybO9XQVupiFsoUInE=",
         "owner": "xmonad",
         "repo": "xmonad",
-        "rev": "a4140b93497333ec7f3127ee4dabcb8ae8a721b6",
+        "rev": "eba9e97794705349f9c6a50230bb88b8ef7d539a",
         "type": "github"
       },
       "original": {

--- a/nix/haskell-package-overrides.nix
+++ b/nix/haskell-package-overrides.nix
@@ -78,7 +78,13 @@ final: prev: let
     scotty = doJailbreak super.scotty; # text <2.1
     broadcast-chan = doJailbreak super.broadcast-chan; # base <4.19
   };
+
+  fixDeps92 = self: super: lib.optionalAttrs (lib.versionOlder super.ghc.version "9.4") {
+    taffybar = super.taffybar.override { inherit (pkgs) gtk3; };
+    gtk-sni-tray = super.gtk-sni-tray.override { inherit (pkgs) gtk3; };
+  };
+
 in
   lib.composeExtensions
     (haskellLib.packageSourceOverrides sourceOverrides)
-    configuration
+    (lib.composeExtensions configuration fixDeps92)

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.8
+cabal-version: 3.4
 name: taffybar
 version: 4.0.3
 synopsis: A desktop bar similar to xmobar, but with more GUI
@@ -8,7 +8,7 @@ author: Ivan Malison
 maintainer: IvanMalison@gmail.com
 category: System
 build-type: Simple
-tested-with: GHC == 9.4.8, GHC == 9.6.6, GHC == 9.8.2
+tested-with: GHC == 9.2.8, GHC == 9.4.8, GHC == 9.6.6, GHC == 9.8.2
 homepage: http://github.com/taffybar/taffybar
 data-files:
   taffybar.css
@@ -188,6 +188,7 @@ executable taffybar
   ghc-options: -Wall -rtsopts -threaded
 
 test-suite unit
+  type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: Spec.hs
   other-modules: System.Taffybar.AuthSpec


### PR DESCRIPTION
Add GHC 9.2 to CI.
It turns out Cabal-version: 3.8 is too high.

Unfortunately the nix magic cache action isn't working very well (github rate limits?).
