### PR TITLE
Fix flakehub upload

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,7 @@
     checks = {
       hlint = pkgs.haskellPackages.taffybar.hlint;
       ghc-warnings = pkgs.haskellPackages.taffybar.fail-on-all-warnings;
+    } // lib.optionalAttrs (system == "x86_64-linux") {
       dependency-graph = weeder-nix.lib.${system}.makeWeederCheck {
         weederToml = ./weeder.toml;
         haskellPackages = pkgs.haskellPackages;

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,9 @@
   outputs = { self, nixpkgs, flake-utils, gtk-sni-tray, gtk-strut, status-notifier-item, xmonad, weeder-nix }: let
     inherit (self) lib;
     inherit (nixpkgs.lib) composeExtensions;
+    inherit (flake-utils.lib) eachSystem;
+
+    supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
 
     # This flake will generate packages using the following compilers
     # from nixpkgs. The "default" package in this flake will be built with
@@ -56,7 +59,7 @@
         });
       });
 
-  } // flake-utils.lib.eachDefaultSystem (system: let
+  } // eachSystem supportedSystems (system: let
     pkgs = import nixpkgs {
       inherit system;
       overlays = [ self.overlays.default ];


### PR DESCRIPTION
1. Limit supported systems of this flake to just Linux.
2. Only build the dependency-graph check on `x86_64-linux`, because this is the only system supported by the [weeder-nix](https://github.com/NorfairKing/weeder-nix) flake.
