### PR TITLE
Reload CSS files on SIGHUP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
  * Add icon next to window label in Windows widget. This can be configured with [`WindowsConfig(getActiveWindowIconPixbuf)`][WindowsConfig].
 
- * If Taffybar is not running in a terminal, then it will reload CSS
-   files whenever the process receives a `SIGHUP` signal.
+ * Taffybar now watches its CSS files with inotify. Changes to CSS
+   should be visible immediately after saving the file.
+
+   If Taffybar is not running in a terminal, and the process receives
+   a `SIGHUP` signal, then it will restart the inotify instance and
+   reload the CSS files.
 
 [WindowsConfig]: https://hackage.haskell.org/package/taffybar-4.0.4/docs/System-Taffybar-Widget-Windows.html#t:WindowsConfig
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
  * Add icon next to window label in Windows widget. This can be configured with [`WindowsConfig(getActiveWindowIconPixbuf)`][WindowsConfig].
 
+ * If Taffybar is not running in a terminal, then it will reload CSS
+   files whenever the process receives a `SIGHUP` signal.
+
 [WindowsConfig]: https://hackage.haskell.org/package/taffybar-4.0.4/docs/System-Taffybar-Widget-Windows.html#t:WindowsConfig
 
 

--- a/doc/custom.md
+++ b/doc/custom.md
@@ -26,8 +26,7 @@ Be aware that the `TaffybarConfig` value required by `dyreTaffybar`/`startTaffyb
 [#308 Add styling tips section to README/docs](https://github.com/taffybar/taffybar/issues/308)
 
 Appearance of Taffybar widgets can be controlled with CSS rules. These
-are by default loaded from `$XDG_CONFIG_HOME/taffybar/taffybar.css`. Taffybar
-must be restarted for changes in `taffybar.css` to take effect.
+are by default loaded from `$XDG_CONFIG_HOME/taffybar/taffybar.css`.
 
 ### GTK Documentation
 
@@ -44,6 +43,22 @@ CSS class names of widgets. The GTK Inspector also lets you
 interactively try CSS rules, which is immensely helpful.
 
 [inspector]: https://developer.gnome.org/documentation/tools/inspector.html
+
+### Reloading CSS
+
+Changes to `taffybar.css` take effect after restarting Taffybar.
+
+But, if Taffybar is running as a daemon, a `SIGHUP` signal on the
+process will cause it to reload the CSS files.
+
+So you could use a file watcher tool such as [entr][] for faster
+feedback while editing CSS rules:
+
+```sh
+entr -s 'kill -HUP `pidof taffybar`' <<< $HOME/.config/taffybar/taffybar.css
+```
+
+[entr]: http://eradman.com/entrproject/
 
 ### Specifying colours
 

--- a/doc/custom.md
+++ b/doc/custom.md
@@ -46,19 +46,12 @@ interactively try CSS rules, which is immensely helpful.
 
 ### Reloading CSS
 
-Changes to `taffybar.css` take effect after restarting Taffybar.
+Taffybar watches `taffybar.css` (and other configured CSS files) for
+modification, so style changes should be visible immediately.
 
-But, if Taffybar is running as a daemon, a `SIGHUP` signal on the
-process will cause it to reload the CSS files.
-
-So you could use a file watcher tool such as [entr][] for faster
-feedback while editing CSS rules:
-
-```sh
-entr -s 'kill -HUP `pidof taffybar`' <<< $HOME/.config/taffybar/taffybar.css
-```
-
-[entr]: http://eradman.com/entrproject/
+But, if the file watching doesn't work for some reason, and Taffybar
+is running as a daemon, a `SIGHUP` signal on the process will force it
+to reload the CSS files.
 
 ### Specifying colours
 

--- a/src/System/Taffybar/Util.hs
+++ b/src/System/Taffybar/Util.hs
@@ -45,6 +45,7 @@ module System.Taffybar.Util (
   , handlePosixSignal
   -- * Resource management
   , rebracket
+  , rebracket_
   -- * Deprecated
   , logPrintFDebug
   , liftReader
@@ -170,6 +171,15 @@ rebracket alloc action = bracket setup teardown (action . reload)
       maybeTeardown stale
       fresh <- alloc
       pure (Just fresh, resource fresh)
+
+-- | A variant of 'rebracket' where the resource value isn't needed.
+--
+-- And because the resource value isn't needed, this variant will
+-- automatically allocate the resource before running the enclosed
+-- action.
+rebracket_ :: IO (IO ()) -> (IO () -> IO a) -> IO a
+rebracket_ alloc action = rebracket ((, ()) <$> alloc) $
+  \reload -> reload >> action reload
 
 -- | Execute the provided IO action at the provided interval.
 foreverWithDelay :: (MonadIO m, RealFrac d) => d -> IO () -> m ThreadId

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -51,6 +51,7 @@ library
                , either >= 4.0.0.0
                , enclosed-exceptions >= 1.0.0.1
                , filepath
+               , fsnotify >= 0.4 && < 0.5
                , gi-cairo-connector
                , gi-cairo-render
                , gi-gdk >=3.0.6 && <3.1


### PR DESCRIPTION
This adds a way to reload CSS without restarting Taffybar.

Restarting Taffybar is quick, but it does make windows flicker a bit, which is not so good for observing results of style changes.

Perhaps in future a D-Bus method could be added, or the files could be watched by hfsnotify. But for me a signal is enough.
