### PR TITLE
Add support of refreshing in PollingLabel (mostly for WttrIn)

### DIFF
--- a/src/System/Taffybar/Widget/WttrIn.hs
+++ b/src/System/Taffybar/Widget/WttrIn.hs
@@ -28,7 +28,7 @@ import Network.HTTP.Client
   )
 import Network.HTTP.Types.Status (statusIsSuccessful)
 import System.Log.Logger (Priority (ERROR), logM)
-import System.Taffybar.Widget.Generic.PollingLabel (pollingLabelNew)
+import System.Taffybar.Widget.Generic.PollingLabel (pollingLabelWithVariableDelayAndRefresh)
 import Text.Regex (matchRegex, mkRegex)
 
 -- | Creates a GTK Label widget that polls the requested wttr.in url for weather
@@ -47,7 +47,10 @@ textWttrNew ::
   -- | Update Interval (in seconds)
   Double ->
   m Widget
-textWttrNew url interval = pollingLabelNew interval (callWttr url)
+textWttrNew url interval = pollingLabelWithVariableDelayAndRefresh action True
+  where action = do
+          rsp <- callWttr url
+          return (rsp, Nothing, interval)
 
 -- | IO Action that calls wttr.in as per the user's request.
 callWttr :: String -> IO T.Text


### PR DESCRIPTION
### Motivation
The WttrIn widget can sometimes encounter network errors or display outdated information. It will be convenient to add a "refreshing" function on these scenes rather than restarting the whole bar, as shown in the figures.

- Network error: <img width="269" height="39" alt="image" src="https://github.com/user-attachments/assets/06ac4cb6-aec9-4465-b45a-f9b7d3117052" />
- Click to refresh the widget: <img width="466" height="44" alt="image" src="https://github.com/user-attachments/assets/db7c8c9d-22c8-4604-9ef7-aef7ef9c0c38" />
- Reloaded result: <img width="625" height="47" alt="image" src="https://github.com/user-attachments/assets/009034e7-3dfd-48f9-a70a-8cc922fb6b0c" />

### Changes
1. The PR adds a 
   ```
   pollingLabelWithVariableDelayAndRefresh
     :: IO (T.Text, Maybe T.Text, Double)
     -> Bool -- ^ Whether to refresh the label on mouse click
     -> m GI.Gtk.Widget
   ```
   function in `System.Taffybar.Widget.Generic.PollingLabel` module. The previous `pollingLabelWithVariableDelay` function remains the same and is a special version of `pollingLabelWithVariableDelayAndRefresh`. 
2. The WttrIn widget created by `textWttrNew` of `System.Taffybar.Widget.WttrIn` can be manually refreshed by a single click.